### PR TITLE
fix: vault core resources invalid reference

### DIFF
--- a/packages/terraform/vault_core_resources/outputs.tf
+++ b/packages/terraform/vault_core_resources/outputs.tf
@@ -1,7 +1,3 @@
-output "vault_internal_pki_path" {
-  value = vault_mount.pki_internal.path
-}
-
 output "vault_ssh_ca_public_key" {
   value = vault_ssh_secret_backend_ca.ssh.public_key
 }

--- a/packages/website/src/app/(web)/docs/reference/terraform-modules/vault_core_resources/page.mdx
+++ b/packages/website/src/app/(web)/docs/reference/terraform-modules/vault_core_resources/page.mdx
@@ -96,10 +96,6 @@ Default: `null`
 
 The following outputs are exported:
 
-### <a name="output_vault_internal_pki_path" /> [vault\_internal\_pki\_path](#output_vault_internal_pki_path)
-
-Description: n/a
-
 ### <a name="output_vault_ssh_ca_public_key" /> [vault\_ssh\_ca\_public\_key](#output_vault_ssh_ca_public_key)
 
 Description: n/a


### PR DESCRIPTION
I removed an output that had a reference to a resource that doesn't exist in the latest version of the module. Confirmed locally that this version of the module deploys correctly 