### PR TITLE
fix/tag-specificity

### DIFF
--- a/packages/nix/mkDevShells/common/setup/files/terragrunt/panfactum.hcl
+++ b/packages/nix/mkDevShells/common/setup/files/terragrunt/panfactum.hcl
@@ -246,5 +246,5 @@ inputs = {
   region           = local.vars.region
   pf_stack_version = local.pf_stack_version
   pf_stack_commit  = local.pf_stack_version_commit_hash
-  extra_tags       = merge(local.module_extra_tags, local.region_extra_tags, local.environment_extra_tags, local.global_extra_tags)
+  extra_tags       = merge(local.global_extra_tags, local.environment_extra_tags, local.region_extra_tags, local.module_extra_tags)
 }

--- a/packages/reference/environments/panfactum.hcl
+++ b/packages/reference/environments/panfactum.hcl
@@ -246,5 +246,5 @@ inputs = {
   region           = local.vars.region
   pf_stack_version = local.pf_stack_version
   pf_stack_commit  = local.pf_stack_version_commit_hash
-  extra_tags       = merge(local.module_extra_tags, local.region_extra_tags, local.environment_extra_tags, local.global_extra_tags)
+  extra_tags       = merge(local.global_extra_tags, local.environment_extra_tags, local.region_extra_tags, local.module_extra_tags)
 }


### PR DESCRIPTION
Per documentation:
 - https://developer.hashicorp.com/terraform/language/functions/merge
 - https://spacelift.io/blog/terraform-merge-function

When there is a conflict in map keys between objects being merged, the _rightmost_ object's values are used.  With this change, reading the `extra_tags` follows the same hierarchy as presented at the top of  `terragrunt.hcl` where yaml files are loaded:
`module > region > environment > global`