### PR TITLE
feat: adds validation for aws_registered_domain.*_phone_number var

### DIFF
--- a/packages/infrastructure/aws_registered_domains/vars.tf
+++ b/packages/infrastructure/aws_registered_domains/vars.tf
@@ -52,6 +52,10 @@ variable "admin_phone_number" {
   description = "The phone number of the domain contact"
   type        = string
   sensitive   = true
+  validation {
+    condition     = can(regex("^\\+\\d{1,3}\\.\\d{1,26}$", var.admin_phone_number)) && length(var.admin_phone_number) <= 30
+    error_message = "The phone number must be in the format +[country dialing code].[number including any area code], e.g., +1.1234567890, with a maximum length of 30 characters."
+  }
 }
 
 variable "admin_address_line_1" {
@@ -114,6 +118,10 @@ variable "registrant_phone_number" {
   description = "The phone number of the domain contact"
   type        = string
   sensitive   = true
+  validation {
+    condition     = can(regex("^\\+\\d{1,3}\\.\\d{1,26}$", var.registrant_phone_number)) && length(var.registrant_phone_number) <= 30
+    error_message = "The phone number must be in the format +[country dialing code].[number including any area code], e.g., +1.1234567890, with a maximum length of 30 characters."
+  }
 }
 
 variable "registrant_address_line_1" {
@@ -176,6 +184,10 @@ variable "tech_phone_number" {
   description = "The phone number of the domain contact"
   type        = string
   sensitive   = true
+  validation {
+    condition     = can(regex("^\\+\\d{1,3}\\.\\d{1,26}$", var.tech_phone_number)) && length(var.tech_phone_number) <= 30
+    error_message = "The phone number must be in the format +[country dialing code].[number including any area code], e.g., +1.1234567890, with a maximum length of 30 characters."
+  }
 }
 
 variable "tech_address_line_1" {


### PR DESCRIPTION
Based on the [issue](https://github.com/Panfactum/stack/issues/43) adding validation for contact phone_number fields to follow [AWS ContactDetail Guidelines](https://docs.aws.amazon.com/Route53/latest/APIReference/API_domains_ContactDetail.html)

## Testing Output

I tested in my infrastructure repository consuming the modified module with validation.

1. Modify secrets.yaml where it contains phone_number to an invalid format i.e 999-123-1234
2. Run `terragrunt plan`

```shell
Planning failed. OpenTofu encountered an error while generating this plan.

╷
│ Error: Invalid value for variable
│
│   on vars.tf line 51:
│   51: variable "admin_phone_number" {
│     ├────────────────
│     │ var.admin_phone_number is "999-123-1234"
│
│ The phone number must be in the format +[country dialing code].[number
│ including any area code], e.g., +1.1234567890, with a maximum length of 30
│ characters.
│
│ This was checked by the validation rule at vars.tf:55,3-13.
╵
╷
│ Error: Invalid value for variable
│
│   on vars.tf line 117:
│  117: variable "registrant_phone_number" {
│     ├────────────────
│     │ var.registrant_phone_number is "999-123-1234"
│
│ The phone number must be in the format +[country dialing code].[number
│ including any area code], e.g., +1.1234567890, with a maximum length of 30
│ characters.
│
│ This was checked by the validation rule at vars.tf:121,3-13.
╵
╷
│ Error: Invalid value for variable
│
│   on vars.tf line 183:
│  183: variable "tech_phone_number" {
│     ├────────────────
│     │ var.tech_phone_number is "999-123-1234"
│
│ The phone number must be in the format +[country dialing code].[number
│ including any area code], e.g., +1.1234567890, with a maximum length of 30
│ characters.
│
│ This was checked by the validation rule at vars.tf:187,3-13.

```

After modifying the phone_number field in `secrets.yaml` to +1.9991231234 I get a successful plan.

```shell
No changes. Your infrastructure matches the configuration.

OpenTofu has compared your real infrastructure against your configuration and
found no differences, so no changes are needed.
```