### PR TITLE
fix(kube_labels): provide a mechanism to omit extra_tags

### DIFF
--- a/packages/infrastructure/kube_labels/main.tf
+++ b/packages/infrastructure/kube_labels/main.tf
@@ -5,7 +5,7 @@ terraform {
 locals {
   sanitized_labels = {
     for k, v in var.extra_tags :
-    replace(replace(replace(k, "/[^a-zA-Z0-9-_.//]/", "."), "/^[^a-zA-Z0-9]+/", ""), "/[^a-zA-Z0-9]+$/", "") => v
+    replace(replace(replace(k, "/[^a-zA-Z0-9-_.//]/", "."), "/^[^a-zA-Z0-9]+/", ""), "/[^a-zA-Z0-9]+$/", "") => v if v != "__omit__"
   }
 
   kube_labels = merge(local.sanitized_labels, {


### PR DESCRIPTION
A potential workaround for https://github.com/Panfactum/stack/issues/46

If accepted, I will also update the module documentation.

```yaml
# region.yaml
extra_tags:
  corgeek.net/test: "value"
  "corgeek:foo": "FOO"
```

```yaml
# module.yaml
extra_tags:
  corgeek.net/test: "value"
  "corgeek:foo": "__omit__"
```

```sh
Changes to Outputs:
  + kube_labels = {
      + "corgeek.net/test"             = "value"
      + "panfactum.com/environment"   = "development"
      + "panfactum.com/local"         = "false"
      + "panfactum.com/module"        = "kube_labels"
      + "panfactum.com/region"        = "us-west-2"
      + "panfactum.com/root-module"   = "kube_labels"
      + "panfactum.com/stack-commit"  = "6900872b7c8a73ef1d501a8399a438ac47d86020"
      + "panfactum.com/stack-version" = "edge.24-05-30"
    }
```