### PR TITLE
fix(kube_aws_lb_controller): use vpc_id in data.aws_subnet.nlb_subnet filter

### DIFF
--- a/packages/infrastructure/kube_aws_lb_controller/main.tf
+++ b/packages/infrastructure/kube_aws_lb_controller/main.tf
@@ -110,6 +110,7 @@ data "aws_vpc" "vpc" {
 
 data "aws_subnet" "nlb_subnets" {
   for_each = var.subnets
+  vpc_id = var.vpc_id
   filter {
     name   = "tag:Name"
     values = [each.value]


### PR DESCRIPTION
In circumstances or situations where there is a single account with multiple VPCs in it, the existing data resource can possibly result in multiple subnets all with the same name.