### PR TITLE
fix: addresses .env not being loadable be new devenv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -11,3 +11,5 @@ if ! use flake . --impure
 then
   echo "devenv could not be built. The devenv environment was not loaded. Make the necessary changes to devenv.nix and hit enter to try again." >&2
 fi
+
+dotenv_if_exists .env

--- a/packages/nix/mkDevShells/setup/files/direnv/envrc
+++ b/packages/nix/mkDevShells/setup/files/direnv/envrc
@@ -11,3 +11,5 @@ if ! use flake . --impure
 then
   echo "devenv could not be built. The devenv environment was not loaded. Make the necessary changes to devenv.nix and hit enter to try again." >&2
 fi
+
+dotenv_if_exists .env

--- a/packages/reference/.envrc
+++ b/packages/reference/.envrc
@@ -11,3 +11,5 @@ if ! use flake . --impure
 then
   echo "devenv could not be built. The devenv environment was not loaded. Make the necessary changes to devenv.nix and hit enter to try again." >&2
 fi
+
+dotenv_if_exists .env


### PR DESCRIPTION
Fixes #52 

According to devenv maintainers, this is a __wontfix__, 

While the old python-rewrite branch supported dotenv files when used via nix flakes, the released 1.0.x rewrite in rust does not. https://github.com/cachix/devenv/issues/1135#issuecomment-2127681361

TLDR, using the released devenv means `.env` files no longer work.