### PR TITLE
feat(kube_vault_proxy): support path-prefix for vault proxy

### DIFF
--- a/packages/infrastructure/kube_vault_proxy/vars.tf
+++ b/packages/infrastructure/kube_vault_proxy/vars.tf
@@ -26,6 +26,12 @@ variable "domain" {
   type        = string
 }
 
+variable "path_prefix" {
+  description = "The domain the proxy is served from"
+  type        = string
+  default     = "/"
+}
+
 variable "vault_domain" {
   description = "The domain of the Vault instance running in the cluster."
   type        = string


### PR DESCRIPTION
Adds support to `kube_vault_proxy` for ingresses that are behind a path prefix instead of a subdomain, e.g.

```
https://my.website.com/public #no oauth-proxy
https://my.website.com/app   #no oauth-proxy
https://my.website.com/storybook #with oauth-proxy
```
Specific changes:
- Adds `path_prefix` option that defaults to `/`
- Uses the `path_prefix` option to construct the oauth/redirect urls.
- Uses the `path_prefix` in `--cookie-path`

## Notes
I have questions about how ingress/dns/certificates would work under the hood here if deploying several different sites with the same domain.