### PR TITLE
fix: ss not found in MacOS

### DIFF
--- a/packages/nix/packages/pf-get-open-port.sh
+++ b/packages/nix/packages/pf-get-open-port.sh
@@ -5,7 +5,16 @@ set -eo pipefail
 # Utility function to return a random open port
 
 # Get a list of all used ports
-USED_PORTS=$(ss -tan | awk 'NR>1 {print $4}' | awk -F':' '{print $NF}' | sort -n | uniq)
+# On MacOS, use netstat -tan instead of ss
+
+if command -v ss &> /dev/null; then
+  USED_PORTS=$(ss -tan | awk 'NR>1 {print $4}' | awk -F':' '{print $NF}' | sort -n | uniq)
+elif command -v netstat &> /dev/null; then
+  USED_PORTS=$(netstat -tan | awk 'NR>2 {print $4}' | awk -F':' '{print $NF}' | sort -n | uniq)
+else
+  echo "Error: ss or netstat not found"
+  exit 1
+fi
 
 # Search for a free PORT by checking against the list of used ports
 START_PORT=$((RANDOM % 9001 + 1024))


### PR DESCRIPTION
Adds a check before using ss and fallsback to netstat. This allows MacOS users to use the pf-buildkit command.

Fixes this issue: https://github.com/Panfactum/stack/issues/68