### PR TITLE
feat[kube_karpenter_node_pools]: support optionally selecting subnets by name instead of tag

### DIFF
--- a/packages/infrastructure/kube_karpenter_node_pools/main.tf
+++ b/packages/infrastructure/kube_karpenter_node_pools/main.tf
@@ -101,7 +101,13 @@ locals {
 
   node_class_template = {
     amiFamily = "Bottlerocket"
-    subnetSelectorTerms = [
+    subnetSelectorTerms = length(var.node_subnets) > 0 ? [for subnetName in var.node_subnets :
+      {
+        tags = {
+          "Name" = subnetName
+        }
+      }
+      ] : [
       {
         tags = {
           "karpenter.sh/discovery" = var.cluster_name

--- a/packages/infrastructure/kube_karpenter_node_pools/vars.tf
+++ b/packages/infrastructure/kube_karpenter_node_pools/vars.tf
@@ -34,3 +34,9 @@ variable "node_labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "node_subnets" {
+  description = "List of subnet names to deploy karpenter nodes into."
+  type        = set(string)
+  default     = []
+}


### PR DESCRIPTION
`kube_karpenter` requires a list of subnet names, however this module doesn't actually use these names outside of creating tags on the subnets.

This tag is then used in the subnet search selector terms for the node pools.  However, for clusters that are deployed into corporate-managed VPCs where the subnets either cannot be tagged, or the tags get overridden, this results in karpenter failing.

This PR adds the option to pass the list to the `kube_karpenter_node_pools` module; it will default to using `karpenter.sh/discovery={cluster_name}`  which is the current behavior.