### PR TITLE
fix(#95): use integers for cpu_milicores above 999

### DIFF
--- a/packages/infrastructure/kube_pg_cluster/main.tf
+++ b/packages/infrastructure/kube_pg_cluster/main.tf
@@ -415,7 +415,8 @@ resource "kubernetes_manifest" "postgres_cluster" {
       resources = {
         requests = {
           memory = "${var.pg_memory_mb}Mi"
-          cpu    = "${var.pg_cpu_millicores}m"
+          cpu    = var.pg_cpu_millicores > 999 ? ceil(var.pg_cpu_millicores / 1000) : "${var.pg_cpu_millicores}m"
+
         }
         limits = {
           memory = "${ceil(var.pg_memory_mb * 1.3)}Mi"


### PR DESCRIPTION
This PR sets the resources cpu divided by 1000 as when setting it to 1000mi fails from the provider level.

After applying in my cluster I see this in the pod definition
![image](https://github.com/user-attachments/assets/3077c22b-40f9-4329-9f81-215fae2f0056)


https://github.com/Panfactum/stack/issues/95