### PR TITLE
feat: adds longer resource timeout for creating pg cluster

### DIFF
--- a/packages/infrastructure/kube_pg_cluster/main.tf
+++ b/packages/infrastructure/kube_pg_cluster/main.tf
@@ -266,6 +266,9 @@ resource "kubernetes_secret" "superuser" {
 ***************************************/
 
 resource "kubernetes_manifest" "postgres_cluster" {
+  timeouts {
+    create = "2h" # Recovery can take a long time given the size of the database. This will avoid timeout that would taint the resource and cause a destroy-recreate loop
+  }
   manifest = {
     apiVersion = "postgresql.cnpg.io/v1"
     kind       = "Cluster"


### PR DESCRIPTION
Given we've been using the recovery process to sync our production database with dev quite often, this opentofu resource block helps prevent running into tainting the resource after a timeout is reached.