### PR TITLE
add back border to top nav for documentation page

### DIFF
--- a/packages/website-2/src/components/layout/header-nav.tsx
+++ b/packages/website-2/src/components/layout/header-nav.tsx
@@ -23,7 +23,7 @@ export interface NavLinks {
 
 const GITHUB_URL = 'https://github.com/Panfactum/stack'
 
-export function HeaderNav({ currentPath, hasBorder, darkBackground = false, ...props }: HeaderNav) {
+export function HeaderNav({ currentPath, hasBorder = true, darkBackground = false, ...props }: HeaderNav) {
   const { link: documentationPath } = useLastDocumentationPath()
 
   const [mobileOpened, setMobileOpened] = useState(false)

--- a/packages/website-2/src/layouts/DocumentationLayout.astro
+++ b/packages/website-2/src/layouts/DocumentationLayout.astro
@@ -9,7 +9,6 @@ import { buildBreadCrumbRoot } from '../components/documentation/DocsSidebar/Sid
 import Footer from '@/components/layout/footer.astro'
 
 const pathname = new URL(Astro.request.url).pathname
-const hasBorder = Astro.props.hasBorder ? Astro.props.hasBorder : false
 const headings = Astro.props.headings || []
 
 const showFooter =
@@ -69,7 +68,7 @@ const breadcrumbs = buildBreadCrumbRoot(Astro.props.versionedSections, pathname)
         currentPath={pathname}
         client:load
         darkBackground={Astro.props.darkBackground}
-        hasBorder={hasBorder}
+        hasBorder={Astro.props.hasBorder}
         transition:persist
       />
 

--- a/packages/website-2/src/layouts/Layout.astro
+++ b/packages/website-2/src/layouts/Layout.astro
@@ -47,6 +47,7 @@ const hasDarkBackground = Astro.props.darkBackground ? Astro.props.darkBackgroun
           client:load
           darkBackground={hasDarkBackground}
           transition:persist
+          hasBorder={Astro.props.hasBorder}
         />
       </div>
 

--- a/packages/website-2/src/pages/about.astro
+++ b/packages/website-2/src/pages/about.astro
@@ -76,7 +76,7 @@ const COMPANY_MEMBERS = [
 ]
 ---
 
-<Layout title="About" darkBackground={true} heroClass="bg-brand-section">
+<Layout title="About" darkBackground={true} heroClass="bg-brand-section" hasBorder={false}>
   <Section slot="hero">
     <div class="flex flex-col gap-3xl items-center text-center max-w-[846px]">
       <Kicker> pæn • fak • tm </Kicker>

--- a/packages/website-2/src/pages/index.astro
+++ b/packages/website-2/src/pages/index.astro
@@ -211,6 +211,7 @@ const PRICES = [
   darkBackground={true}
   heroClass="bg-brand-section lg:bg-hero-pattern bg-[center_top] bg-cover bg-no-repeat"
   isFixed={false}
+  hasBorder={false}
 >
   <HeroSection
     slot="hero"

--- a/packages/website-2/src/pages/pricing.astro
+++ b/packages/website-2/src/pages/pricing.astro
@@ -42,7 +42,7 @@ const DISCOUNTS = [
 ]
 ---
 
-<Layout title="Pricing" darkBackground={true} heroClass="bg-brand-section">
+<Layout title="Pricing" darkBackground={true} heroClass="bg-brand-section" hasBorder={false}>
   <section slot="hero" class="flex space-y-7xl flex-col items-center py-9xl">
     <div
       class="container flex flex-col items-center space-y-6xl px-container-padding-mobile xl:px-container-padding-desktop"


### PR DESCRIPTION
1. the top navbar bottom border was missing in documentation pages.  
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set default `hasBorder` to `true` in `HeaderNav` to ensure navbar border on documentation pages, with overrides in specific layouts.
> 
>   - **Behavior**:
>     - Set default `hasBorder` to `true` in `HeaderNav` in `header-nav.tsx` to ensure navbar border is present by default.
>     - Removed redundant `hasBorder` logic in `DocumentationLayout.astro`.
>   - **Layout Changes**:
>     - Added `hasBorder={Astro.props.hasBorder}` to `HeaderNav` in `Layout.astro`.
>     - Set `hasBorder={false}` in `about.astro`, `index.astro`, and `pricing.astro` to override default behavior where needed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Panfactum%2Fstack&utm_source=github&utm_medium=referral)<sup> for 069ead42c71e4a830de6518ad44ee063d67c7950. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->