### PR TITLE
add padding to sidebar menu

### DIFF
--- a/packages/website-2/src/components/documentation/DocsSidebar.tsx
+++ b/packages/website-2/src/components/documentation/DocsSidebar.tsx
@@ -187,7 +187,7 @@ export function DocsSidebar({
       setOpenMobile={setOpenMobile}
     >
       <SidebarContent>
-        <SidebarMenu className="relative pb-0 md:pb-10 pl-4 pr-4">
+        <SidebarMenu className="relative pb-0 md:pb-10 pl-4 pr-4 pt-4">
           <div
             className={`flex flex-col gap-y-lg sticky h-full top-0 bg-primary z-top-navigation`}
           >
@@ -239,7 +239,7 @@ export function DocsSidebar({
           <Spacer />
 
           {currentRoot && (
-            <SidebarGroup>
+            <SidebarGroup className="pt-4">
               <SidebarMenu>
                 {currentRoot.sub?.map((section) => {
                   const sectionBasePath = `${basePath}${currentRoot.notVersioned ? '' : `/${version}`}${currentRoot.path}`


### PR DESCRIPTION
1. add padding to sidebar menu for documentations
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add top padding to `SidebarMenu` and `SidebarGroup` in `DocsSidebar.tsx`.
> 
>   - **UI Changes**:
>     - Add `pt-4` class to `SidebarMenu` in `DocsSidebar.tsx` for top padding.
>     - Add `pt-4` class to `SidebarGroup` in `DocsSidebar.tsx` for top padding.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Panfactum%2Fstack&utm_source=github&utm_medium=referral)<sup> for 7835829c9181baa2f4c87e6c061d80b27c9ce0c3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->