### PR TITLE
adding new inputs (s3_bucket_access_policy & pg_wall_size_keep) for kube_pg_cluster

### DIFF
--- a/packages/infrastructure/aws_s3_private_bucket/main.tf
+++ b/packages/infrastructure/aws_s3_private_bucket/main.tf
@@ -162,13 +162,8 @@ resource "aws_s3_bucket_intelligent_tiering_configuration" "bucket" {
   }
 }
 
-data "aws_iam_policy_document" "access_policy_doc" {
-  source_policy_documents = var.access_policy == null ? [] : [var.access_policy]
-}
-
 data "aws_iam_policy_document" "default_policy" {
-  override_policy_documents = var.access_policy == null ? [] : [data.aws_iam_policy_document.access_policy_doc.json]
-
+  override_policy_documents = var.access_policy == null ? [] : [var.access_policy]
   statement {
     sid     = "RootAccess"
     effect  = "Allow"

--- a/packages/infrastructure/aws_s3_private_bucket/main.tf
+++ b/packages/infrastructure/aws_s3_private_bucket/main.tf
@@ -162,10 +162,13 @@ resource "aws_s3_bucket_intelligent_tiering_configuration" "bucket" {
   }
 }
 
-
+data "aws_iam_policy_document" "access_policy_doc" {
+  source_policy_documents = var.access_policy == null ? [] : [var.access_policy]
+}
 
 data "aws_iam_policy_document" "default_policy" {
-  override_policy_documents = var.access_policy == null ? [] : [var.access_policy]
+  override_policy_documents = var.access_policy == null ? [] : [data.aws_iam_policy_document.access_policy_doc.json]
+
   statement {
     sid     = "RootAccess"
     effect  = "Allow"

--- a/packages/infrastructure/kube_argo_event_source/main.tf
+++ b/packages/infrastructure/kube_argo_event_source/main.tf
@@ -87,6 +87,8 @@ resource "kubectl_manifest" "event_source" {
         metadata = {
           labels = module.util.labels
         }
+
+        serviceAccountName = kubernetes_service_account.service_account.metadata[0].name
         tolerations   = module.util.tolerations
         affinity      = module.util.affinity
         schedulerName = module.util.scheduler_name

--- a/packages/infrastructure/kube_argo_event_source/main.tf
+++ b/packages/infrastructure/kube_argo_event_source/main.tf
@@ -99,7 +99,7 @@ resource "kubectl_manifest" "event_source" {
             runAsGroup             = 1000
             runAsNonRoot           = true
             readOnlyRootFilesystem = true
-            drop = ["ALL"]
+            drop                   = ["ALL"]
           }
         }
       }
@@ -109,7 +109,7 @@ resource "kubectl_manifest" "event_source" {
 
   wait_for {
     field {
-      key = "status.conditions.[0].status" # The Deployed condition
+      key   = "status.conditions.[0].status" # The Deployed condition
       value = "True"
     }
   }
@@ -133,7 +133,7 @@ resource "kubectl_manifest" "vpa" {
         updateMode = "Auto"
         evictionRequirements = [
           {
-            resources = ["cpu", "memory"]
+            resources         = ["cpu", "memory"]
             changeRequirement = "TargetHigherThanRequests"
           }
         ]
@@ -147,7 +147,7 @@ resource "kubectl_manifest" "vpa" {
   })
   force_conflicts   = true
   server_side_apply = true
-  depends_on = [kubectl_manifest.event_source]
+  depends_on        = [kubectl_manifest.event_source]
 }
 
 resource "kubectl_manifest" "pdb" {

--- a/packages/infrastructure/kube_argo_event_source/main.tf
+++ b/packages/infrastructure/kube_argo_event_source/main.tf
@@ -89,9 +89,9 @@ resource "kubectl_manifest" "event_source" {
         }
 
         serviceAccountName = kubernetes_service_account.service_account.metadata[0].name
-        tolerations   = module.util.tolerations
-        affinity      = module.util.affinity
-        schedulerName = module.util.scheduler_name
+        tolerations        = module.util.tolerations
+        affinity           = module.util.affinity
+        schedulerName      = module.util.scheduler_name
         container = {
           resources = local.default_resources
           securityContext = {
@@ -99,7 +99,7 @@ resource "kubectl_manifest" "event_source" {
             runAsGroup             = 1000
             runAsNonRoot           = true
             readOnlyRootFilesystem = true
-            drop                   = ["ALL"]
+            drop = ["ALL"]
           }
         }
       }
@@ -109,7 +109,7 @@ resource "kubectl_manifest" "event_source" {
 
   wait_for {
     field {
-      key   = "status.conditions.[0].status" # The Deployed condition
+      key = "status.conditions.[0].status" # The Deployed condition
       value = "True"
     }
   }
@@ -131,10 +131,12 @@ resource "kubectl_manifest" "vpa" {
     spec = {
       updatePolicy = {
         updateMode = "Auto"
-        evictionRequirements = [{
-          resources         = ["cpu", "memory"]
-          changeRequirement = "TargetHigherThanRequests"
-        }]
+        evictionRequirements = [
+          {
+            resources = ["cpu", "memory"]
+            changeRequirement = "TargetHigherThanRequests"
+          }
+        ]
       }
       targetRef = {
         apiVersion = "argoproj.io/v1alpha1"
@@ -145,7 +147,7 @@ resource "kubectl_manifest" "vpa" {
   })
   force_conflicts   = true
   server_side_apply = true
-  depends_on        = [kubectl_manifest.event_source]
+  depends_on = [kubectl_manifest.event_source]
 }
 
 resource "kubectl_manifest" "pdb" {

--- a/packages/infrastructure/kube_pg_cluster/main.tf
+++ b/packages/infrastructure/kube_pg_cluster/main.tf
@@ -369,7 +369,7 @@ resource "kubernetes_manifest" "postgres_cluster" {
             shared_preload_libraries   = ""
             ssl_max_protocol_version   = "TLSv1.3"
             ssl_min_protocol_version   = "TLSv1.3"
-            wal_keep_size              = var.pg_wal_keep_size_gb
+            wal_keep_size              = "${var.pg_wal_keep_size_gb}GB"
             wal_level                  = "logical"
             wal_log_hints              = "on"
             wal_receiver_timeout       = "5s"

--- a/packages/infrastructure/kube_pg_cluster/main.tf
+++ b/packages/infrastructure/kube_pg_cluster/main.tf
@@ -60,8 +60,8 @@ resource "terraform_data" "validate_pg_wal_sizes" {
 
   lifecycle {
     precondition {
-      condition     = var.pg_max_slot_wal_keep_size_gb == -1 || var.pg_max_slot_wal_keep_size_gb >= var.pg_wal_keep_size_gb
-      error_message = "pg_max_slot_wal_keep_size_gb must be -1 (unlimited) or greater than pg_wal_keep_size_gb"
+      condition     = var.pg_max_slot_wal_keep_size_gb >= var.pg_wal_keep_size_gb
+      error_message = "pg_max_slot_wal_keep_size_gb must be greater than pg_wal_keep_size_gb"
     }
   }
 }
@@ -331,7 +331,7 @@ resource "kubernetes_manifest" "postgres_cluster" {
         annotations = {
           "linkerd.io/inject"                    = "enabled"
           "config.linkerd.io/skip-inbound-ports" = "5432" # Postgres communication is already tls-secured by CNPG
-          "resize.topolvm.io/storage_limit"      = "${var.pg_storage_limit_gb != null ? var.pg_storage_limit_gb : max(100, 10 * var.pg_initial_storage_gb)}Gi"
+          "resize.topolvm.io/storage_limit"      = "${var.pg_storage_limit_gb != null ? var.pg_storage_limit_gb : (max(100, 10 * var.pg_initial_storage_gb) + var.pg_max_slot_wal_keep_size_gb)}Gi"
           "resize.topolvm.io/increase"           = "${var.pg_storage_increase_gb}Gi"
           "resize.topolvm.io/threshold"          = "${var.pg_storage_increase_threshold_percent}%"
         }
@@ -489,7 +489,7 @@ resource "kubernetes_manifest" "postgres_cluster" {
         pvcTemplate = {
           resources = {
             requests = {
-              storage = "${var.pg_initial_storage_gb}Gi"
+              storage = "${var.pg_initial_storage_gb + var.pg_max_slot_wal_keep_size_gb}Gi"
             }
           }
           storageClassName = "ebs-standard"

--- a/packages/infrastructure/kube_pg_cluster/main.tf
+++ b/packages/infrastructure/kube_pg_cluster/main.tf
@@ -53,6 +53,11 @@ locals {
     "panfactum.com/voluntary-disruption-window-max-unavailable" = "1"
     "panfactum.com/voluntary-disruption-window-seconds"         = tostring(var.voluntary_disruption_window_seconds)
   }
+
+  validate_pg_wal_sizes = (
+  var.pg_max_slot_wal_keep_size_gb == -1 ||
+  var.pg_max_slot_wal_keep_size_gb >= var.pg_wal_keep_size_gb
+  ) ? true : tobool("pg_max_slot_wal_keep_size_gb must be greater than pg_wal_keep_size_gb")
 }
 
 data "pf_kube_labels" "labels" {

--- a/packages/infrastructure/kube_pg_cluster/main.tf
+++ b/packages/infrastructure/kube_pg_cluster/main.tf
@@ -309,24 +309,7 @@ resource "kubernetes_manifest" "postgres_cluster" {
         clientCASecret       = module.client_certs.secret_name
         replicationTLSSecret = module.client_certs.secret_name
       }
-        pooler = {
-            enable = var.pgbouncer_read_only_enabled || var.pgbouncer_read_write_enabled
-            replicas = {
-            r  = var.pgbouncer_read_only_enabled ? 1 : 0
-            rw = var.pgbouncer_read_write_enabled ? 1 : 0
-            }
-            resources = {
-            requests = {
-                cpu    = "${var.pg_pooler_cpu_millicores}m"
-                memory = "${var.pg_pooler_memory_mb}Mi"
-            }
-            }
-            imageName = "${module.pull_through.github_registry}/cloudnative-pg/pgbouncer:${var.pg_version}"
-            labels    = merge(
-            module.util_pooler[each.key].labels,
-            { "pg-cluster" = local.cluster-label }
-            )
-        }
+        
       inheritedMetadata = {
         labels = merge(
           module.util_cluster.labels,

--- a/packages/infrastructure/kube_pg_cluster/main.tf
+++ b/packages/infrastructure/kube_pg_cluster/main.tf
@@ -146,6 +146,8 @@ module "s3_bucket" {
   audit_log_enabled               = false
   intelligent_transitions_enabled = false // db operator takes care of garbage collection
   force_destroy                   = var.backups_force_delete
+
+  access_policy = var.s3_bucket_access_policy
 }
 
 moved {
@@ -367,12 +369,12 @@ resource "kubernetes_manifest" "postgres_cluster" {
             shared_preload_libraries   = ""
             ssl_max_protocol_version   = "TLSv1.3"
             ssl_min_protocol_version   = "TLSv1.3"
-            wal_keep_size              = "2GB"
+            wal_keep_size              = var.pg_wal_keep_size_gb
             wal_level                  = "logical"
             wal_log_hints              = "on"
             wal_receiver_timeout       = "5s"
             wal_sender_timeout         = "5s"
-            max_slot_wal_keep_size     = "10GB"
+            max_slot_wal_keep_size     = "${var.pg_wal_keep_size_gb * 3}GB"
 
             # Memory tuning - Based on guide created by EDB (creators of CNPG)
             # https://www.enterprisedb.com/postgres-tutorials/how-tune-postgresql-memory

--- a/packages/infrastructure/kube_pg_cluster/main.tf
+++ b/packages/infrastructure/kube_pg_cluster/main.tf
@@ -374,7 +374,7 @@ resource "kubernetes_manifest" "postgres_cluster" {
             wal_log_hints              = "on"
             wal_receiver_timeout       = "5s"
             wal_sender_timeout         = "5s"
-            max_slot_wal_keep_size     = "${var.pg_wal_keep_size_gb * 3}GB"
+            max_slot_wal_keep_size     = "${var.pg_max_slot_wal_keep_size_gb}GB"
 
             # Memory tuning - Based on guide created by EDB (creators of CNPG)
             # https://www.enterprisedb.com/postgres-tutorials/how-tune-postgresql-memory

--- a/packages/infrastructure/kube_pg_cluster/main.tf
+++ b/packages/infrastructure/kube_pg_cluster/main.tf
@@ -325,7 +325,7 @@ resource "kubernetes_manifest" "postgres_cluster" {
         annotations = {
           "linkerd.io/inject"                    = "enabled"
           "config.linkerd.io/skip-inbound-ports" = "5432" # Postgres communication is already tls-secured by CNPG
-          "resize.topolvm.io/storage_limit"      = "${var.pg_storage_limit_gb != null ? var.pg_storage_limit_gb : max(100, 10 * var.pg_initial_storage_gb)}Gi"
+          "resize.topolvm.io/storage_limit"      = "${var.pg_storage_limit_gb != null ? var.pg_storage_limit_gb : max(100, 10 * var.pg_initial_storage_gb + var.pg_max_slot_wal_keep_size_gb)}Gi"
           "resize.topolvm.io/increase"           = "${var.pg_storage_increase_gb}Gi"
           "resize.topolvm.io/threshold"          = "${var.pg_storage_increase_threshold_percent}%"
         }

--- a/packages/infrastructure/kube_pg_cluster/main.tf
+++ b/packages/infrastructure/kube_pg_cluster/main.tf
@@ -61,7 +61,7 @@ resource "terraform_data" "validate_pg_wal_sizes" {
   lifecycle {
     precondition {
       condition     = var.pg_max_slot_wal_keep_size_gb >= var.pg_wal_keep_size_gb
-      error_message = "pg_max_slot_wal_keep_size_gb must be greater than pg_wal_keep_size_gb"
+      error_message = "pg_max_slot_wal_keep_size_gb must be greater than or equal to pg_wal_keep_size_gb"
     }
   }
 }
@@ -331,7 +331,7 @@ resource "kubernetes_manifest" "postgres_cluster" {
         annotations = {
           "linkerd.io/inject"                    = "enabled"
           "config.linkerd.io/skip-inbound-ports" = "5432" # Postgres communication is already tls-secured by CNPG
-          "resize.topolvm.io/storage_limit"      = "${var.pg_storage_limit_gb != null ? var.pg_storage_limit_gb : (max(100, 10 * var.pg_initial_storage_gb) + var.pg_max_slot_wal_keep_size_gb)}Gi"
+          "resize.topolvm.io/storage_limit"      = "${(var.pg_storage_limit_gb != null ? var.pg_storage_limit_gb : max(100, 10 * var.pg_initial_storage_gb)) + var.pg_max_slot_wal_keep_size_gb}Gi"
           "resize.topolvm.io/increase"           = "${var.pg_storage_increase_gb}Gi"
           "resize.topolvm.io/threshold"          = "${var.pg_storage_increase_threshold_percent}%"
         }

--- a/packages/infrastructure/kube_pg_cluster/outputs.tf
+++ b/packages/infrastructure/kube_pg_cluster/outputs.tf
@@ -144,5 +144,3 @@ output "recovery_directory" {
   value       = random_id.recovery_directory.hex
 }
 
-
-

--- a/packages/infrastructure/kube_pg_cluster/vars.tf
+++ b/packages/infrastructure/kube_pg_cluster/vars.tf
@@ -554,3 +554,15 @@ variable "create_timeout_minutes" {
   type        = number
   default     = 60
 }
+
+variable "s3_bucket_access_policy" {
+  description = "Additional AWS access policy for the S3 bucket. https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#argument-reference"
+  type        = string
+  default     = null
+}
+
+variable "pg_wal_keep_size_gb" {
+  description = "The number of gigabytes of WAL files to keep for the cluster"
+  type        = number
+  default     = 2
+}

--- a/packages/infrastructure/kube_pg_cluster/vars.tf
+++ b/packages/infrastructure/kube_pg_cluster/vars.tf
@@ -571,9 +571,4 @@ variable "pg_max_slot_wal_keep_size_gb" {
   description = "Maximum size in gigabytes of WAL files that replication slots can retain before old segments are removed."
   type        = number
   default     = 10
-
-  validation {
-    condition     = var.pg_max_slot_wal_keep_size_gb >= 10 && var.pg_max_slot_wal_keep_size_gb <= 100
-    error_message = "pg_max_slot_wal_keep_size_gb must be between 10 and 100."
-  }
 }

--- a/packages/infrastructure/kube_pg_cluster/vars.tf
+++ b/packages/infrastructure/kube_pg_cluster/vars.tf
@@ -556,7 +556,7 @@ variable "create_timeout_minutes" {
 }
 
 variable "s3_bucket_access_policy" {
-  description = "Additional AWS access policy for the S3 bucket. https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#argument-reference"
+  description = "Additional AWS access policy for the backup S3 bucket. https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#argument-reference"
   type        = string
   default     = null
 }

--- a/packages/infrastructure/kube_pg_cluster/vars.tf
+++ b/packages/infrastructure/kube_pg_cluster/vars.tf
@@ -568,7 +568,7 @@ variable "pg_wal_keep_size_gb" {
 }
 
 variable "pg_max_slot_wal_keep_size_gb" {
-  description = "Maximum size in megabytes of WAL files that replication slots can retain before old segments are removed."
+  description = "Maximum size in gigabytes of WAL files that replication slots can retain before old segments are removed."
   type        = number
   default     = 10
 }

--- a/packages/infrastructure/kube_pg_cluster/vars.tf
+++ b/packages/infrastructure/kube_pg_cluster/vars.tf
@@ -571,4 +571,9 @@ variable "pg_max_slot_wal_keep_size_gb" {
   description = "Maximum size in gigabytes of WAL files that replication slots can retain before old segments are removed."
   type        = number
   default     = 10
+
+  validation {
+    condition     = var.pg_max_slot_wal_keep_size_gb >= 10 && var.pg_max_slot_wal_keep_size_gb <= 100
+    error_message = "pg_max_slot_wal_keep_size_gb must be between 10 and 100."
+  }
 }

--- a/packages/infrastructure/kube_pg_cluster/vars.tf
+++ b/packages/infrastructure/kube_pg_cluster/vars.tf
@@ -566,3 +566,9 @@ variable "pg_wal_keep_size_gb" {
   type        = number
   default     = 2
 }
+
+variable "pg_max_slot_wal_keep_size_gb" {
+  description = "Maximum size in megabytes of WAL files that replication slots can retain before old segments are removed."
+  type        = number
+  default     = 10
+}

--- a/packages/reference/flake.lock
+++ b/packages/reference/flake.lock
@@ -165,7 +165,7 @@
       },
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-Gf1us1e4SQog2OGOh5hyBn/nvNkqBuXIbpADneTXj2Y=",
+        "narHash": "sha256-+/dHpnh8Zdvdu9wQojbQaqnXMyAWsFeKZ3ZM+sZUCC0=",
         "path": "../..",
         "type": "path"
       },

--- a/packages/website/src/content/docs/changelog/edge.mdx
+++ b/packages/website/src/content/docs/changelog/edge.mdx
@@ -25,6 +25,9 @@ import MarkdownAlert from "@/components/markdown/MarkdownAlert.astro";
 * Adds new inputs to [kube_pg_cluster](/docs/edge/reference/infrastructure-modules/submodule/kubernetes/kube_pg_cluster) for configuring the
   [PostgreSQL WAL Size](/docs/edge/reference/infrastructure-modules/submodule/kubernetes/kube_pg_cluster#pg_wal_keep_size_gb) settings and adding additional [AWS S3 access policies](/docs/edge/reference/infrastructure-modules/submodule/kubernetes/kube_pg_cluster#s3_bucket_access_policy) for the s3 bucket
 
+### Fixed
+* Fixes where the service account name is not set for the event source pod in [kube_argo_event_source](/docs/edge/reference/infrastructure-modules/submodule/kubernetes/kube_argo_event_source)
+
 ### Changed
 
 * Node-local image caching is now enabled by default in Panfactum submodules.

--- a/packages/website/src/content/docs/changelog/edge.mdx
+++ b/packages/website/src/content/docs/changelog/edge.mdx
@@ -21,7 +21,7 @@ import MarkdownAlert from "@/components/markdown/MarkdownAlert.astro";
 
 ### Added
 
-* Adds [authentik_atlas_mongodb_sso](/docs/main/reference/infrastructure-modules/direct/authentik/authentik_mongodb_atlas_sso) & [mongodb_atlas_identity_provider](/docs/main/reference/infrastructure-modules/direct/authentik/mongodb_atlas_identity_provider) module for setting up the Authentik Application and Provider for Atlas MongoDB.
+* Adds [authentik_atlas_mongodb_sso](/docs/edge/reference/infrastructure-modules/direct/authentik/authentik_mongodb_atlas_sso) & [mongodb_atlas_identity_provider](/docs/edge/reference/infrastructure-modules/direct/authentik/mongodb_atlas_identity_provider) module for setting up the Authentik Application and Provider for Atlas MongoDB.
 * Adds new inputs to [kube_pg_cluster](/docs/edge/reference/infrastructure-modules/submodule/kubernetes/kube_pg_cluster) for configuring the
   [pg_wal_keep_size_gb](/docs/edge/reference/infrastructure-modules/submodule/kubernetes/kube_pg_cluster#pg_wal_keep_size_gb) settings and adding additional [s3_bucket_access_policy](/docs/edge/reference/infrastructure-modules/submodule/kubernetes/kube_pg_cluster#s3_bucket_access_policy) for the s3 bucket
 

--- a/packages/website/src/content/docs/changelog/edge.mdx
+++ b/packages/website/src/content/docs/changelog/edge.mdx
@@ -22,6 +22,8 @@ import MarkdownAlert from "@/components/markdown/MarkdownAlert.astro";
 ### Added
 
 * Adds [authentik_atlas_mongodb_sso](/docs/main/reference/infrastructure-modules/direct/authentik/authentik_mongodb_atlas_sso) & [mongodb_atlas_identity_provider](/docs/main/reference/infrastructure-modules/direct/authentik/mongodb_atlas_identity_provider) module for setting up the Authentik Application and Provider for Atlas MongoDB.
+* Adds new inputs to [kube_pg_cluster](/docs/edge/reference/infrastructure-modules/submodule/kubernetes/kube_pg_cluster) for configuring the
+  [PostgreSQL WAL Size](/docs/edge/reference/infrastructure-modules/submodule/kubernetes/kube_pg_cluster#pg_wal_keep_size_gb) settings and adding additional [AWS S3 access policies](/docs/edge/reference/infrastructure-modules/submodule/kubernetes/kube_pg_cluster#s3_bucket_access_policy) for the s3 bucket
 
 ### Changed
 

--- a/packages/website/src/content/docs/changelog/edge.mdx
+++ b/packages/website/src/content/docs/changelog/edge.mdx
@@ -23,7 +23,7 @@ import MarkdownAlert from "@/components/markdown/MarkdownAlert.astro";
 
 * Adds [authentik_atlas_mongodb_sso](/docs/main/reference/infrastructure-modules/direct/authentik/authentik_mongodb_atlas_sso) & [mongodb_atlas_identity_provider](/docs/main/reference/infrastructure-modules/direct/authentik/mongodb_atlas_identity_provider) module for setting up the Authentik Application and Provider for Atlas MongoDB.
 * Adds new inputs to [kube_pg_cluster](/docs/edge/reference/infrastructure-modules/submodule/kubernetes/kube_pg_cluster) for configuring the
-  [PostgreSQL WAL Size](/docs/edge/reference/infrastructure-modules/submodule/kubernetes/kube_pg_cluster#pg_wal_keep_size_gb) settings and adding additional [AWS S3 access policies](/docs/edge/reference/infrastructure-modules/submodule/kubernetes/kube_pg_cluster#s3_bucket_access_policy) for the s3 bucket
+  [pg_wal_keep_size_gb](/docs/edge/reference/infrastructure-modules/submodule/kubernetes/kube_pg_cluster#pg_wal_keep_size_gb) settings and adding additional [s3_bucket_access_policy](/docs/edge/reference/infrastructure-modules/submodule/kubernetes/kube_pg_cluster#s3_bucket_access_policy) for the s3 bucket
 
 ### Fixed
 * Fixes where the service account name is not set for the event source pod in [kube_argo_event_source](/docs/edge/reference/infrastructure-modules/submodule/kubernetes/kube_argo_event_source)

--- a/packages/website/src/content/docs/main/reference/infrastructure-modules/submodule/kubernetes/kube_pg_cluster/index.mdx
+++ b/packages/website/src/content/docs/main/reference/infrastructure-modules/submodule/kubernetes/kube_pg_cluster/index.mdx
@@ -658,6 +658,14 @@ Type: `string`
 
 Default: `"16.6-13"`
 
+### pg\_wal\_keep\_size\_gb
+
+Description: The number of gigabytes of WAL files to keep for the cluster
+
+Type: `number`
+
+Default: `2`
+
 ### pg\_work\_mem\_percent
 
 Description: The percent of the overall memory allocation available to queries for sort and hash operations (intermediate calculations during queries)
@@ -985,6 +993,14 @@ Description: Whether to use the ECR pull through cache for the deployed images
 Type: `bool`
 
 Default: `false`
+
+### s3\_bucket\_access\_policy
+
+Description: Additional AWS access policy for the S3 bucket. https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#argument-reference
+
+Type: `string`
+
+Default: `null`
 
 ### spot\_nodes\_enabled
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds new inputs for S3 bucket access and WAL size to `kube_pg_cluster`, and fixes service account name in `kube_argo_event_source`.
> 
>   - **Behavior**:
>     - Adds `s3_bucket_access_policy` and `pg_wal_keep_size_gb` inputs to `kube_pg_cluster/main.tf` for configuring S3 bucket access and WAL file retention.
>     - Updates `pg_max_slot_wal_keep_size_gb` to ensure it is greater than or equal to `pg_wal_keep_size_gb`.
>     - Fixes service account name setting in `kube_argo_event_source/main.tf`.
>   - **Documentation**:
>     - Updates `edge.mdx` changelog to include new inputs for `kube_pg_cluster` and fix in `kube_argo_event_source`.
>     - Updates `kube_pg_cluster/index.mdx` to document new inputs and their usage.
>   - **Misc**:
>     - Minor formatting changes in `aws_s3_private_bucket/main.tf` and `kube_pg_cluster/outputs.tf`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Panfactum%2Fstack&utm_source=github&utm_medium=referral)<sup> for f13ceed25dbca966044e0ca73d278435e6f1cab6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->