### PR TITLE
Add test-user-service

### DIFF
--- a/packages/reference/environments/production/us-east-2/test_user_service/terragrunt.hcl
+++ b/packages/reference/environments/production/us-east-2/test_user_service/terragrunt.hcl
@@ -1,0 +1,39 @@
+include "panfactum" {
+  path   = find_in_parent_folders("panfactum.hcl")
+  expose = true
+}
+
+terraform {
+  source = include.panfactum.locals.source
+}
+
+dependency "ingress" {
+  config_path  = "../kube_ingress_nginx"
+  skip_outputs = true
+}
+
+dependency "cluster" {
+  config_path = "../aws_eks"
+}
+
+dependency "redis_cache" {
+  config_path = "../demo_redis_cache"
+}
+
+inputs = {
+  namespace = "test-user-service"
+
+  domain            = "test.panfactum.com"
+  image_version     = run_cmd("--terragrunt-quiet", "pf-get-commit-hash", "--ref=main", "--repo=https://github.com/panfactum/stack")
+  healthcheck_route = "/health"
+  db_name           = "postgres"
+  db_schema         = "app"
+  secret            = "test_secret"
+
+  redis_master_set         = dependency.redis_cache.outputs.master_set
+  redis_cache_creds_secret = dependency.redis_cache.outputs.superuser_creds_secret
+
+  redis_cache_sentinel_enabled = true
+  redis_cache_sentinel_host    = dependency.redis_cache.outputs.sentinel_host
+  redis_cache_sentinel_port    = dependency.redis_cache.outputs.sentinel_port
+}

--- a/packages/reference/infrastructure/test_user_service/main.tf
+++ b/packages/reference/infrastructure/test_user_service/main.tf
@@ -1,0 +1,133 @@
+terraform {
+  required_providers {
+    pf = {
+      source = "panfactum/pf"
+    }
+  }
+}
+
+locals {
+  name = "test-user-service"
+  namespace = module.namespace.namespace
+  port = 3000
+}
+
+module "namespace" {
+  source =   "${var.pf_module_source}kube_namespace${var.pf_module_ref}"
+  namespace = local.name
+}
+
+module "database" {
+  source = "${var.pf_module_source}kube_pg_cluster${var.pf_module_ref}"
+
+  pg_cluster_namespace                 = local.namespace
+  aws_iam_ip_allow_list                = []
+
+  pg_initial_storage_gb                = 5    # for the purposes of the test
+  pg_max_connections                   = 20   # for the purposes of the test
+  pg_instances                         = 2    # for the purposes of the test
+  burstable_nodes_enabled              = true # for the purposes of the test
+
+  pull_through_cache_enabled           = var.pull_through_cache_enabled
+  monitoring_enabled                   = var.monitoring_enabled
+  panfactum_scheduler_enabled          = var.panfactum_scheduler_enabled
+  instance_type_anti_affinity_required = var.enhanced_ha_enabled
+}
+
+module "test_user_service_deployment" {
+  source = "${var.pf_module_source}kube_deployment${var.pf_module_ref}"
+  namespace = module.namespace.namespace
+  name      = local.name
+
+  replicas                             = 2
+
+  common_env = {
+    NODE_ENV = "production"
+    PORT     = local.port
+    HOST = "0.0.0.0"
+    DB_HOST  = module.database.pooler_rw_service_name
+    DB_PORT  = module.database.pooler_rw_service_port
+    DB_NAME  = var.db_name
+    DB_SCHEMA = var.db_schema
+    SECRET = var.secret
+
+    REDIS_SENTINEL_ENABLED = true
+    REDIS_SENTINEL_HOST = var.redis_cache_sentinel_host
+    REDIS_SENTINEL_PORT = var.redis_cache_sentinel_port
+    REDIS_MASTER_SET = var.redis_master_set
+  }
+
+  common_env_from_secrets = {
+    DB_USER = {
+      secret_name = module.database.superuser_creds_secret
+      key = "username"
+    }
+
+    DB_PASSWORD = {
+      secret_name = module.database.superuser_creds_secret
+      key         = "password"
+    }
+
+    REDIS_USERNAME = {
+      secret_name = var.redis_cache_creds_secret
+      key = "username"
+    }
+
+    REDIS_PASSWORD = {
+      secret_name = var.redis_cache_creds_secret
+      key = "password"
+    }
+  }
+
+  containers = [
+    {
+      name    = "test-user-service"
+      image_registry   = "891377197483.dkr.ecr.us-east-2.amazonaws.com"
+      image_repository = "demo-user-service"
+      image_tag = var.image_version
+      command = [
+        "node",
+        "index.js"
+      ]
+      liveness_probe_type  = "HTTP"
+      liveness_probe_port  = local.port
+      liveness_probe_route = var.healthcheck_route
+      minimum_memory = 200
+      ports = {
+        http ={
+          port = local.port
+        }
+      }
+    }
+  ]
+
+  vpa_enabled = var.vpa_enabled
+  controller_nodes_enabled = true
+
+  depends_on = [module.database]
+}
+
+module "ingress" {
+  source = "${var.pf_module_source}kube_ingress${var.pf_module_ref}"
+
+  name      = local.name
+  namespace = local.namespace
+
+  domains      = [var.domain]
+  ingress_configs = [{
+    path_prefix = "/user"
+    remove_prefix = true
+    service      = local.name
+    service_port = local.port
+  }]
+
+  cdn_mode_enabled = false
+  cors_enabled                   = true
+  cross_origin_embedder_policy   = "credentialless"
+  csp_enabled                    = true
+  cross_origin_isolation_enabled = true
+  rate_limiting_enabled          = true
+  permissions_policy_enabled     = true
+
+  depends_on = [module.test_user_service_deployment]
+}

--- a/packages/reference/infrastructure/test_user_service/vars.tf
+++ b/packages/reference/infrastructure/test_user_service/vars.tf
@@ -1,0 +1,100 @@
+variable "domain" {
+  description = "A list of domains from which the ingress will serve traffic"
+  type        = string
+}
+
+variable "image_version" {
+  description = "The version of the test user service image to deploy"
+  type        = string
+}
+
+variable "healthcheck_route" {
+  description = "The route to use for the healthcheck"
+  type        = string
+}
+
+variable "db_name" {
+  description = "The name of the database"
+  type        = string
+}
+
+variable "db_schema" {
+  description = "The schema of the database"
+  type        = string
+}
+
+variable "secret" {
+  description = "The secret to used for jwt validation"
+  type        = string
+}
+
+variable "redis_cache_sentinel_host" {
+  description = "The host of the redis sentinel cache"
+  type        = string
+}
+
+variable "redis_cache_sentinel_port" {
+  description = "The port of the redis sentinel cache"
+  type        = number
+}
+
+variable "redis_master_set" {
+  description = "The master set to use when configuring Sentinel-aware Redis clients"
+  type        = string
+}
+
+variable "redis_cache_creds_secret" {
+  description = "The name of the Kubernetes Secret holding credentials for the Redis database"
+  type        = string
+}
+
+variable "pull_through_cache_enabled" {
+  description = "Whether to use the ECR pull through cache for the deployed images"
+  type        = bool
+  default     = true
+}
+
+variable "burstable_nodes_enabled" {
+  description = "Whether to enable burstable nodes for the postgres cluster"
+  type        = bool
+  default     = true
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace to deploy the resources into"
+  type        = string
+}
+
+variable "vpa_enabled" {
+  description = "Whether the VPA resources should be enabled"
+  type        = bool
+  default     = true
+}
+
+variable "monitoring_enabled" {
+  description = "Whether to add active monitoring to the deployed systems"
+  type        = bool
+  default     = false
+}
+
+variable "enhanced_ha_enabled" {
+  description = "Whether to add extra high-availability scheduling constraints at the trade-off of increased cost"
+  type        = bool
+  default     = true
+}
+
+variable "panfactum_scheduler_enabled" {
+  description = "Whether to use the Panfactum pod scheduler with enhanced bin-packing"
+  type        = bool
+  default     = true
+}
+
+variable "pf_module_source" {
+  description = "The source of the Panfactum modules"
+  type        = string
+}
+
+variable "pf_module_ref" {
+  description = "The reference of the Panfactum modules"
+  type        = string
+}


### PR DESCRIPTION
https://panfactum.slack.com/docs/T07GBM1FL02/F08G9TGUCDP?focus_section_id=temp:C:DNA503b0b2163f14e8bbc3cebb37


  ## Summary
  - Create test-user-service module and deployment configuration
  - Uses the same structure as demo-user-service with a separate database
  - Points to test.panfactum.com domain

  ## Test plan
  - Deploy the test-user-service to a test environment
  - Verify that the service is accessible at test.panfactum.com/user
  - Test API endpoints to ensure functionality matches demo-user-service