### PR TITLE
fix: reset cert manager on nginx ingress deploy

### DIFF
--- a/packages/cli/bun.lock
+++ b/packages/cli/bun.lock
@@ -13,6 +13,7 @@
         "@aws-sdk/client-s3": "^3.787.0",
         "@aws-sdk/client-sts": "^3.787.0",
         "@inquirer/prompts": "^7.4.0",
+        "@kubernetes/client-node": "^1.1.2",
         "@listr2/prompt-adapter-inquirer": "^2.0.21",
         "@types/ini": "^4.1.1",
         "clipanion": "^4.0.0-rc.4",
@@ -212,6 +213,14 @@
 
     "@inquirer/type": ["@inquirer/type@1.5.5", "", { "dependencies": { "mute-stream": "^1.0.0" } }, "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA=="],
 
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+
+    "@jsep-plugin/assignment": ["@jsep-plugin/assignment@1.3.0", "", { "peerDependencies": { "jsep": "^0.4.0||^1.0.0" } }, "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ=="],
+
+    "@jsep-plugin/regex": ["@jsep-plugin/regex@1.0.4", "", { "peerDependencies": { "jsep": "^0.4.0||^1.0.0" } }, "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg=="],
+
+    "@kubernetes/client-node": ["@kubernetes/client-node@1.1.2", "", { "dependencies": { "@types/js-yaml": "^4.0.1", "@types/node": "^22.0.0", "@types/node-fetch": "^2.6.9", "@types/stream-buffers": "^3.0.3", "@types/tar": "^6.1.1", "@types/ws": "^8.5.4", "form-data": "^4.0.0", "hpagent": "^1.2.0", "isomorphic-ws": "^5.0.0", "js-yaml": "^4.1.0", "jsonpath-plus": "^10.3.0", "node-fetch": "^2.6.9", "openid-client": "^6.1.3", "rfc4648": "^1.3.0", "socks-proxy-agent": "^8.0.4", "stream-buffers": "^3.0.2", "tar": "^7.0.0", "tmp-promise": "^3.0.2", "ws": "^8.18.0" } }, "sha512-kkE0D8zB5rIQoR6SUwlHUyQtpLvrW0gXOd2MabQsql7I2oPnMA8pb50A1MWB4yH0eX29t45gxs7lOVlS0UPsiw=="],
+
     "@listr2/prompt-adapter-inquirer": ["@listr2/prompt-adapter-inquirer@2.0.21", "", { "dependencies": { "@inquirer/type": "^1.5.5" }, "peerDependencies": { "@inquirer/prompts": ">= 3 < 8" } }, "sha512-can62OlOPusZwYfKfd0SV6znsSFbiuJw/lvvRSAAdzqUCTE/Vn8FydLGAfEvGbDALdfqvazSj6tnVJKQxj9iXw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.8", "", { "dependencies": { "@emnapi/core": "^1.4.0", "@emnapi/runtime": "^1.4.0", "@tybys/wasm-util": "^0.9.0" } }, "sha512-OBlgKdX7gin7OIq4fadsjpg+cp2ZphvAIKucHsNfTdJiqdOmOEwQd/bHi0VwNrcw5xpBJyUw6cK/QilCqy1BSg=="],
@@ -336,13 +345,21 @@
 
     "@types/ini": ["@types/ini@4.1.1", "", {}, "sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg=="],
 
+    "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
+
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
 
     "@types/node": ["@types/node@22.14.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA=="],
 
+    "@types/node-fetch": ["@types/node-fetch@2.6.12", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.0" } }, "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA=="],
+
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
+
+    "@types/stream-buffers": ["@types/stream-buffers@3.0.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-azOCy05sXVXrO+qklf0c/B07H/oHaIuDDAiHPVwlk3A9Ek+ksHyTeMajLZl3r76FxpPpxem//4Te61G1iW3Giw=="],
+
+    "@types/tar": ["@types/tar@6.1.13", "", { "dependencies": { "@types/node": "*", "minipass": "^4.0.0" } }, "sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw=="],
 
     "@types/uuid": ["@types/uuid@9.0.8", "", {}, "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="],
 
@@ -398,6 +415,8 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
+    "agent-base": ["agent-base@7.1.3", "", {}, "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw=="],
+
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
     "ansi-escapes": ["ansi-escapes@7.0.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw=="],
@@ -421,6 +440,8 @@
     "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ=="],
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
@@ -454,6 +475,8 @@
 
     "chardet": ["chardet@0.7.0", "", {}, "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="],
 
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+
     "ci-info": ["ci-info@4.2.0", "", {}, "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg=="],
 
     "clean-regexp": ["clean-regexp@1.0.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw=="],
@@ -471,6 +494,8 @@
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
@@ -493,6 +518,8 @@
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
@@ -592,6 +619,8 @@
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
+    "form-data": ["form-data@4.0.2", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "mime-types": "^2.1.12" } }, "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w=="],
+
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "function.prototype.name": ["function.prototype.name@1.1.8", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "functions-have-names": "^1.2.3", "hasown": "^2.0.2", "is-callable": "^1.2.7" } }, "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q=="],
@@ -636,6 +665,8 @@
 
     "hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
 
+    "hpagent": ["hpagent@1.2.0", "", {}, "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA=="],
+
     "iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
@@ -653,6 +684,8 @@
     "init": ["init@0.1.2", "", { "dependencies": { "daemon": ">=0.3.0" } }, "sha512-IvHUjULS2q+BXJdiu4FHkByh3+qSFmkOXQ2ItSfYTtkdUksQc0yNX6f1uDyokzRV71tjpFsFc3ckeYLJXunTGw=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "ip-address": ["ip-address@9.0.5", "", { "dependencies": { "jsbn": "1.1.0", "sprintf-js": "^1.1.3" } }, "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g=="],
 
     "is-array-buffer": ["is-array-buffer@3.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A=="],
 
@@ -712,9 +745,17 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "isomorphic-ws": ["isomorphic-ws@5.0.0", "", { "peerDependencies": { "ws": "*" } }, "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw=="],
+
+    "jose": ["jose@6.0.10", "", {}, "sha512-skIAxZqcMkOrSwjJvplIPYrlXGpxTPnro2/QWTDCxAdWQrSTV5/KqspMWmi5WAx5+ULswASJiZ0a+1B/Lxt9cw=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
+
+    "jsbn": ["jsbn@1.1.0", "", {}, "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="],
+
+    "jsep": ["jsep@1.4.0", "", {}, "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -725,6 +766,8 @@
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
     "json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
+
+    "jsonpath-plus": ["jsonpath-plus@10.3.0", "", { "dependencies": { "@jsep-plugin/assignment": "^1.3.0", "@jsep-plugin/regex": "^1.0.4", "jsep": "^1.4.0" }, "bin": { "jsonpath": "bin/jsonpath-cli.js", "jsonpath-plus": "bin/jsonpath-cli.js" } }, "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA=="],
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
@@ -748,6 +791,10 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
@@ -756,15 +803,25 @@
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
+    "minipass": ["minipass@4.2.8", "", {}, "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="],
+
+    "minizlib": ["minizlib@3.0.2", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA=="],
+
+    "mkdirp": ["mkdirp@3.0.1", "", { "bin": { "mkdirp": "dist/cjs/src/bin.js" } }, "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "mute-stream": ["mute-stream@1.0.0", "", {}, "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
     "node-releases": ["node-releases@2.0.19", "", {}, "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="],
 
     "normalize-package-data": ["normalize-package-data@6.0.2", "", { "dependencies": { "hosted-git-info": "^7.0.0", "semver": "^7.3.5", "validate-npm-package-license": "^3.0.4" } }, "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g=="],
+
+    "oauth4webapi": ["oauth4webapi@3.5.0", "", {}, "sha512-DF3mLWNuxPkxJkHmWxbSFz4aE5CjWOsm465VBfBdWzmzX4Mg3vF8icxK+iKqfdWrIumBJ2TaoNQWx+SQc2bsPQ=="],
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
@@ -779,6 +836,8 @@
     "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "openid-client": ["openid-client@6.4.2", "", { "dependencies": { "jose": "^6.0.10", "oauth4webapi": "^3.4.1" } }, "sha512-4zBRTsKNRTyKxV5cFzl+LtamsYx/FsWhejjax+qgMkFNGtLj1gMtng2iSoJqqWUT0FHU3IUhO53aeBePg7Sp/g=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -844,6 +903,8 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
+    "rfc4648": ["rfc4648@1.5.4", "", {}, "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg=="],
+
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
@@ -882,6 +943,12 @@
 
     "slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
 
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.4", "", { "dependencies": { "ip-address": "^9.0.5", "smart-buffer": "^4.2.0" } }, "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ=="],
+
+    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
+
     "spdx-correct": ["spdx-correct@3.2.0", "", { "dependencies": { "spdx-expression-parse": "^3.0.0", "spdx-license-ids": "^3.0.0" } }, "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA=="],
 
     "spdx-exceptions": ["spdx-exceptions@2.5.0", "", {}, "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="],
@@ -890,7 +957,11 @@
 
     "spdx-license-ids": ["spdx-license-ids@3.0.21", "", {}, "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg=="],
 
+    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
+
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
+
+    "stream-buffers": ["stream-buffers@3.0.3", "", {}, "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw=="],
 
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
@@ -918,15 +989,21 @@
 
     "synckit": ["synckit@0.11.2", "", { "dependencies": { "@pkgr/core": "^0.2.0", "tslib": "^2.8.1" } }, "sha512-1IUffI8zZ8qUMB3NUJIjk0RpLroG/8NkQDAWH1NbB2iJ0/5pn3M8rxfNzMz4GH9OnYaGYn31LEDSXJp/qIlxgA=="],
 
+    "tar": ["tar@7.4.3", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.0.1", "mkdirp": "^3.0.1", "yallist": "^5.0.0" } }, "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw=="],
+
     "terminal-columns": ["terminal-columns@2.0.0", "", {}, "sha512-6IByuUjyNZJXUtwDNm+OIe62zgwwaRbH+WMNTcx05O2G5V9WhvluAAHJY8OvUdwmzMPpqAD/7EUpGdI6ae1aiQ=="],
 
     "terminal-link": ["terminal-link@4.0.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "supports-hyperlinks": "^3.2.0" } }, "sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA=="],
 
     "tinyglobby": ["tinyglobby@0.2.12", "", { "dependencies": { "fdir": "^6.4.3", "picomatch": "^4.0.2" } }, "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww=="],
 
-    "tmp": ["tmp@0.0.33", "", { "dependencies": { "os-tmpdir": "~1.0.2" } }, "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw=="],
+    "tmp": ["tmp@0.2.3", "", {}, "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w=="],
+
+    "tmp-promise": ["tmp-promise@3.0.3", "", { "dependencies": { "tmp": "^0.2.0" } }, "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
 
@@ -966,6 +1043,10 @@
 
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
 
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "which-boxed-primitive": ["which-boxed-primitive@1.1.1", "", { "dependencies": { "is-bigint": "^1.1.0", "is-boolean-object": "^1.2.1", "is-number-object": "^1.1.1", "is-string": "^1.1.1", "is-symbol": "^1.1.1" } }, "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA=="],
@@ -979,6 +1060,10 @@
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wrap-ansi": ["wrap-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q=="],
+
+    "ws": ["ws@8.18.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w=="],
+
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
 
@@ -1044,6 +1129,8 @@
 
     "@inquirer/select/ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
+    "@isaacs/fs-minipass/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
@@ -1064,6 +1151,8 @@
 
     "eslint-plugin-unicorn/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
 
+    "external-editor/tmp": ["tmp@0.0.33", "", { "dependencies": { "os-tmpdir": "~1.0.2" } }, "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw=="],
+
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "is-builtin-module/builtin-modules": ["builtin-modules@4.0.0", "", {}, "sha512-p1n8zyCkt1BVrKNFymOHjcDSAl7oq/gUvfgULv2EblgpPVQlQr9yHnWjg9IJ2MhfwPqiYqMMrr01OY7yQoK2yA=="],
@@ -1074,11 +1163,15 @@
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "minizlib/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+
     "normalize-package-data/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
 
     "regjsparser/jsesc": ["jsesc@3.0.2", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="],
 
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "tar/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 

--- a/packages/cli/bun.nix
+++ b/packages/cli/bun.nix
@@ -1508,6 +1508,61 @@ let
         hash = "sha256-idzqxLbC3jj3aS+dBonQyBPymQCiByPomlej2WAbFck=";
       };
     };
+    "@isaacs/fs-minipass" = {
+      out_path = "@isaacs/fs-minipass";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "@isaacs/fs-minipass@4.0.1";
+        url = "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz";
+        hash = "sha256-esKG48zMHqiYDnniA53va7l9MYLheVHNkJTwQA7ZgjY=";
+      };
+    };
+    "@isaacs/fs-minipass/minipass" = {
+      out_path = "@isaacs/fs-minipass/node_modules/minipass";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "minipass@7.1.2";
+        url = "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz";
+        hash = "sha256-VI9WGhlDSXElTwnyFITGv50bnQN82sYjEGFrNRxE1RY=";
+      };
+    };
+    "@jsep-plugin/assignment" = {
+      out_path = "@jsep-plugin/assignment";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "@jsep-plugin/assignment@1.3.0";
+        url = "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz";
+        hash = "sha256-MPb+rch3UeGCDqdtiv8tjm17MUKQyGeQZ57jPBqOCMs=";
+      };
+    };
+    "@jsep-plugin/regex" = {
+      out_path = "@jsep-plugin/regex";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "@jsep-plugin/regex@1.0.4";
+        url = "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz";
+        hash = "sha256-uEFrIJpMegGu5P9yGvFuOXRyytb5IjQ6zDWFo91HPRo=";
+      };
+    };
+    "@kubernetes/client-node" = {
+      out_path = "@kubernetes/client-node";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "@kubernetes/client-node@1.1.2";
+        url = "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-1.1.2.tgz";
+        hash = "sha256-IuOTjq9gZwzHdhOjwex32E6gtb16SxYqpWpnR71zCNA=";
+      };
+    };
     "@listr2/prompt-adapter-inquirer" = {
       out_path = "@listr2/prompt-adapter-inquirer";
       binaries =
@@ -2190,6 +2245,17 @@ let
         hash = "sha256-ZqOUuwpbEg9eTyFWPoa8HETa6EvPsSNnAibRJUy2z/g=";
       };
     };
+    "@types/js-yaml" = {
+      out_path = "@types/js-yaml";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "@types/js-yaml@4.0.9";
+        url = "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz";
+        hash = "sha256-jJojQYj0LjXQpPklbI/ylysyFVWMBbQv6WuKyF1glP0=";
+      };
+    };
     "@types/json-schema" = {
       out_path = "@types/json-schema";
       binaries =
@@ -2223,6 +2289,17 @@ let
         hash = "sha256-qqJ1AIAiWnO8mlXCrHi7DdA0GeKj6iPtD8jp0dDIkSk=";
       };
     };
+    "@types/node-fetch" = {
+      out_path = "@types/node-fetch";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "@types/node-fetch@2.6.12";
+        url = "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz";
+        hash = "sha256-FzZKDSJd5kvtt+h1NAVBptjblVwOZ4ugjsnDT/57HLc=";
+      };
+    };
     "@types/normalize-package-data" = {
       out_path = "@types/normalize-package-data";
       binaries =
@@ -2232,6 +2309,28 @@ let
         name = "@types/normalize-package-data@2.4.4";
         url = "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz";
         hash = "sha256-5y7XImebHw/nCh2cqPXK45zSpfIYXkxtMELlrmCf3ys=";
+      };
+    };
+    "@types/stream-buffers" = {
+      out_path = "@types/stream-buffers";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "@types/stream-buffers@3.0.7";
+        url = "https://registry.npmjs.org/@types/stream-buffers/-/stream-buffers-3.0.7.tgz";
+        hash = "sha256-YjuLHomWlC0GUcOgzMXdAqGta46dSbOLdtBDOgwBxUI=";
+      };
+    };
+    "@types/tar" = {
+      out_path = "@types/tar";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "@types/tar@6.1.13";
+        url = "https://registry.npmjs.org/@types/tar/-/tar-6.1.13.tgz";
+        hash = "sha256-Xk9kJBBhLtRHJmj8DgkDYUpvEb0yH/maHOzuhleJ33A=";
       };
     };
     "@types/uuid" = {
@@ -2564,6 +2663,17 @@ let
         hash = "sha256-2WewXkDFOWpW1w4NMVBHe5actswQWNaLwrlasBWRWMw=";
       };
     };
+    "agent-base" = {
+      out_path = "agent-base";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "agent-base@7.1.3";
+        url = "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz";
+        hash = "sha256-mUmLHGbF+A5fSv3WhzVmqt3oHPkn1fDl35fs/sAmTGQ=";
+      };
+    };
     "ajv" = {
       out_path = "ajv";
       binaries =
@@ -2694,6 +2804,17 @@ let
         name = "async-function@1.0.0";
         url = "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz";
         hash = "sha256-wZa/lZxUeHBKo5wR0th85eBdnMbSDD8E/M73QQLMb9w=";
+      };
+    };
+    "asynckit" = {
+      out_path = "asynckit";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "asynckit@0.4.0";
+        url = "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz";
+        hash = "sha256-jCVPMPcHkmRQQuTXH1kOxJ+OOGpHV3L3QwxzuWS1fc8=";
       };
     };
     "available-typed-arrays" = {
@@ -2872,6 +2993,17 @@ let
         hash = "sha256-Wjq6t2nPSgWabF0100CF+/568sf1HwpMzf57drDG7+c=";
       };
     };
+    "chownr" = {
+      out_path = "chownr";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "chownr@3.0.0";
+        url = "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz";
+        hash = "sha256-TCT12qYwFCJS2oneZV998JDqR5RQqIJYl3UdeDIbE2A=";
+      };
+    };
     "ci-info" = {
       out_path = "ci-info";
       binaries =
@@ -2980,6 +3112,17 @@ let
         name = "colorette@2.0.20";
         url = "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz";
         hash = "sha256-P34nlmM7AOPwXFwZJTr8ONta+xx6aUvNkr9Ky1ImS2I=";
+      };
+    };
+    "combined-stream" = {
+      out_path = "combined-stream";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "combined-stream@1.0.8";
+        url = "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz";
+        hash = "sha256-tr5aq+U+kGNb63fNDgunrmolyM+QOxX8w0I1PnMuFRI=";
       };
     };
     "concat-map" = {
@@ -3101,6 +3244,17 @@ let
         name = "define-properties@1.2.1";
         url = "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz";
         hash = "sha256-XefjgE+t7p13PNSUtpXm7+3+6IN+dR/Zubd8PpxrQPQ=";
+      };
+    };
+    "delayed-stream" = {
+      out_path = "delayed-stream";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "delayed-stream@1.0.0";
+        url = "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz";
+        hash = "sha256-rDj85CF9+x13JCfH2NDQc+NezYMpFel6YdmrXFBBKdM=";
       };
     };
     "doctrine" = {
@@ -3565,6 +3719,17 @@ let
         hash = "sha256-xm+A8QrO34W0Zr9riEjkq3Tt1uAOGMSED6WF//0impA=";
       };
     };
+    "external-editor/tmp" = {
+      out_path = "external-editor/node_modules/tmp";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "tmp@0.0.33";
+        url = "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz";
+        hash = "sha256-0jshXmzkVPB24WOj/rehtUjd9EvjpBNT90g3cisR1sU=";
+      };
+    };
     "fast-deep-equal" = {
       out_path = "fast-deep-equal";
       binaries =
@@ -3739,6 +3904,17 @@ let
         name = "for-each@0.3.5";
         url = "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz";
         hash = "sha256-S9LPyOZ0yTz3q7O9PW/Y44j6EDJL7AESI6j6TyhxhdE=";
+      };
+    };
+    "form-data" = {
+      out_path = "form-data";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "form-data@4.0.2";
+        url = "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz";
+        hash = "sha256-z1sVkak1ZuPvWxTEtqa/dXrHGupmE9Mp+pwRKFQV9UA=";
       };
     };
     "function-bind" = {
@@ -3983,6 +4159,17 @@ let
         hash = "sha256-Z3M6Nx/NyutVKG546khb2Hea9btIZqmEoNDNQ1cy2io=";
       };
     };
+    "hpagent" = {
+      out_path = "hpagent";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "hpagent@1.2.0";
+        url = "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz";
+        hash = "sha256-fKYae5xxGGhBtnbPSWhHwg2WzcnE2ZR7UjHNpRhHI7E=";
+      };
+    };
     "iconv-lite" = {
       out_path = "iconv-lite";
       binaries =
@@ -4080,6 +4267,17 @@ let
         name = "internal-slot@1.1.0";
         url = "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz";
         hash = "sha256-GEm8C8ALgEm/zNfULDofhiIalm1MqzXAKTGdZbOKOIw=";
+      };
+    };
+    "ip-address" = {
+      out_path = "ip-address";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "ip-address@9.0.5";
+        url = "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz";
+        hash = "sha256-nBXSRJTfgVu9GGaShA7LubzPxCbGKsW2BL4897DSdss=";
       };
     };
     "is-array-buffer" = {
@@ -4423,6 +4621,28 @@ let
         hash = "sha256-R8/ocuCI4oxTtzb+8wUyS1fMHPyfcqmw92n5JzHLg1k=";
       };
     };
+    "isomorphic-ws" = {
+      out_path = "isomorphic-ws";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "isomorphic-ws@5.0.0";
+        url = "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz";
+        hash = "sha256-VKp80W8UkO50647v0xVXZp6K+BE+VkcXviSa0jr7ofo=";
+      };
+    };
+    "jose" = {
+      out_path = "jose";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "jose@6.0.10";
+        url = "https://registry.npmjs.org/jose/-/jose-6.0.10.tgz";
+        hash = "sha256-/dcu5/7oE16Xc83MQ01vdtXSXh/I91u79zNSOAbrRT8=";
+      };
+    };
     "js-tokens" = {
       out_path = "js-tokens";
       binaries =
@@ -4443,6 +4663,28 @@ let
         name = "js-yaml@4.1.0";
         url = "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz";
         hash = "sha256-Da4zJVnPIrIcJupw5zKv2DA/+ZQS+cPZ0gn6qIgs8so=";
+      };
+    };
+    "jsbn" = {
+      out_path = "jsbn";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "jsbn@1.1.0";
+        url = "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz";
+        hash = "sha256-R8r6lxcJuxkyQu+Ff7JZNuzZUiodRKAc5IWHI6AGrEU=";
+      };
+    };
+    "jsep" = {
+      out_path = "jsep";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "jsep@1.4.0";
+        url = "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz";
+        hash = "sha256-xu5mko0XxZsXwWmjy3ZuAEzyhnS40I3Uy9Gp+2vQw+o=";
       };
     };
     "jsesc" = {
@@ -4498,6 +4740,18 @@ let
         name = "json5@1.0.2";
         url = "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz";
         hash = "sha256-kLL2digkadW+tAlDADqBXjDoDPhOo9crgSp+E7C32As=";
+      };
+    };
+    "jsonpath-plus" = {
+      out_path = "jsonpath-plus";
+      binaries = {
+        "jsonpath" = "../jsonpath-plus/bin/jsonpath-cli.js";
+        "jsonpath-plus" = "../jsonpath-plus/bin/jsonpath-cli.js";
+      };
+      pkg = fetchurl {
+        name = "jsonpath-plus@10.3.0";
+        url = "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz";
+        hash = "sha256-98j9XlGsA26pAuZ9kyoCr2uilypmizvGzyJF8LRBRIU=";
       };
     };
     "jsx-ast-utils" = {
@@ -4665,6 +4919,28 @@ let
         hash = "sha256-GxTunshnwJDXtSx3GT2D53kQVTs9GLL4bdK3tV6CwR8=";
       };
     };
+    "mime-db" = {
+      out_path = "mime-db";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "mime-db@1.52.0";
+        url = "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz";
+        hash = "sha256-uOcLtNUqzV0NHthIwObjyQOlM6pQCs/74APwEbGPnjs=";
+      };
+    };
+    "mime-types" = {
+      out_path = "mime-types";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "mime-types@2.1.35";
+        url = "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz";
+        hash = "sha256-SXNPyYkG6bqqz4A0kjRwpMhN5ylDp8AF+s5jNgcB0cM=";
+      };
+    };
     "mimic-function" = {
       out_path = "mimic-function";
       binaries =
@@ -4709,6 +4985,50 @@ let
         hash = "sha256-NQp2wRWzk8GdJGVINCYeXcnw6MxeCPOTf6gBQPPkzoM=";
       };
     };
+    "minipass" = {
+      out_path = "minipass";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "minipass@4.2.8";
+        url = "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz";
+        hash = "sha256-NAd9+KDtpph6G1SAjRJ0VzP7Uua+qEkDkEeLNpIP0wQ=";
+      };
+    };
+    "minizlib" = {
+      out_path = "minizlib";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "minizlib@3.0.2";
+        url = "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz";
+        hash = "sha256-+lzmblFJvORri1k4RniS7Q6MDvsFjG6jk3CIyPDvp90=";
+      };
+    };
+    "minizlib/minipass" = {
+      out_path = "minizlib/node_modules/minipass";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "minipass@7.1.2";
+        url = "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz";
+        hash = "sha256-VI9WGhlDSXElTwnyFITGv50bnQN82sYjEGFrNRxE1RY=";
+      };
+    };
+    "mkdirp" = {
+      out_path = "mkdirp";
+      binaries = {
+        "mkdirp" = "../mkdirp/dist/cjs/src/bin.js";
+      };
+      pkg = fetchurl {
+        name = "mkdirp@3.0.1";
+        url = "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz";
+        hash = "sha256-/Hp8PTV7ufJl547zjRCPGqK9hunngdW8woJQs9zcjr8=";
+      };
+    };
     "ms" = {
       out_path = "ms";
       binaries =
@@ -4742,6 +5062,17 @@ let
         hash = "sha256-XlVp7NEgZPc2MqjBikWx0d5KJ7aZpnGGSAHxw17nee4=";
       };
     };
+    "node-fetch" = {
+      out_path = "node-fetch";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "node-fetch@2.7.0";
+        url = "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz";
+        hash = "sha256-pwNIZpsB22AvrxQOmE5hsBxDgPm0v15GC3lgkCQSgys=";
+      };
+    };
     "node-releases" = {
       out_path = "node-releases";
       binaries =
@@ -4773,6 +5104,17 @@ let
         name = "semver@7.7.1";
         url = "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz";
         hash = "sha256-Dxu6Zt/NN/UsYqM6USTi8vccltvIAge4MP/LyM1bXeU=";
+      };
+    };
+    "oauth4webapi" = {
+      out_path = "oauth4webapi";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "oauth4webapi@3.5.0";
+        url = "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.5.0.tgz";
+        hash = "sha256-Es/8phqEyh1nH8R9jyKHgKv2DfI1dwXEsMAsxP11xDk=";
       };
     };
     "object-inspect" = {
@@ -4850,6 +5192,17 @@ let
         name = "onetime@7.0.0";
         url = "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz";
         hash = "sha256-4zVpdDQkVqYdkJrzO02mvbpGz7g/G6igOe6x+6lFzcQ=";
+      };
+    };
+    "openid-client" = {
+      out_path = "openid-client";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "openid-client@6.4.2";
+        url = "https://registry.npmjs.org/openid-client/-/openid-client-6.4.2.tgz";
+        hash = "sha256-FMwuGAWS9dvK+amsEMH5y1Ka+gx4frOaive5yQxZ7UE=";
       };
     };
     "optionator" = {
@@ -5215,6 +5568,17 @@ let
         hash = "sha256-JGAARBIQDuqOlrmPFNPftOIqZihlTlQx0U+XTGIByhg=";
       };
     };
+    "rfc4648" = {
+      out_path = "rfc4648";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "rfc4648@1.5.4";
+        url = "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.4.tgz";
+        hash = "sha256-nnCWZekU4wn5sWJe+L2O66dpeEDVcHiz1YoF+S5BrPU=";
+      };
+    };
     "rfdc" = {
       out_path = "rfdc";
       binaries =
@@ -5435,6 +5799,39 @@ let
         hash = "sha256-aPDnPT8um3lKOI3H9OmhmCcCc6C8pIzWjc+eCM88XRg=";
       };
     };
+    "smart-buffer" = {
+      out_path = "smart-buffer";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "smart-buffer@4.2.0";
+        url = "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz";
+        hash = "sha256-PZgV5MvRvrlHrGvI4z631NOA54H/9pbCybVQlq9kUKE=";
+      };
+    };
+    "socks" = {
+      out_path = "socks";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "socks@2.8.4";
+        url = "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz";
+        hash = "sha256-vNiz3UJnHq9zPb0N0KZ62KFNNysJ/ikGNqR9xkL5bew=";
+      };
+    };
+    "socks-proxy-agent" = {
+      out_path = "socks-proxy-agent";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "socks-proxy-agent@8.0.5";
+        url = "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz";
+        hash = "sha256-1DmvkTAfhOtrrxkJKO+roH2zma2eYCv9SyS6JAz/wfY=";
+      };
+    };
     "spdx-correct" = {
       out_path = "spdx-correct";
       binaries =
@@ -5479,6 +5876,17 @@ let
         hash = "sha256-RXZLU/wEbDV5UZNz30E9McbaPECDTGMTljhxcJOKAk0=";
       };
     };
+    "sprintf-js" = {
+      out_path = "sprintf-js";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "sprintf-js@1.1.3";
+        url = "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz";
+        hash = "sha256-moU3kozdLphwVfXPOK4Z20otS3HEZkilHxVpikjerrY=";
+      };
+    };
     "stable-hash" = {
       out_path = "stable-hash";
       binaries =
@@ -5488,6 +5896,17 @@ let
         name = "stable-hash@0.0.5";
         url = "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz";
         hash = "sha256-SqFeIpxsfXCAV4nlSAq0di4Cjn7lzyNoqnI+tmb9BOk=";
+      };
+    };
+    "stream-buffers" = {
+      out_path = "stream-buffers";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "stream-buffers@3.0.3";
+        url = "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.3.tgz";
+        hash = "sha256-7lfp8db96MuD6fYNnvDsBM79rgDPakK9Wxf2OwN6zDg=";
       };
     };
     "string-width" = {
@@ -5633,6 +6052,28 @@ let
         hash = "sha256-Rt0RvGggA/QKxCgw7KllbxYK9NSwDE5a+YYOTWhxHrs=";
       };
     };
+    "tar" = {
+      out_path = "tar";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "tar@7.4.3";
+        url = "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz";
+        hash = "sha256-EKCBcHdion8VtZhCaD5VRCUhcTFym9asLIpnZrattmc=";
+      };
+    };
+    "tar/minipass" = {
+      out_path = "tar/node_modules/minipass";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "minipass@7.1.2";
+        url = "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz";
+        hash = "sha256-VI9WGhlDSXElTwnyFITGv50bnQN82sYjEGFrNRxE1RY=";
+      };
+    };
     "terminal-columns" = {
       out_path = "terminal-columns";
       binaries =
@@ -5672,9 +6113,20 @@ let
         {
         };
       pkg = fetchurl {
-        name = "tmp@0.0.33";
-        url = "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz";
-        hash = "sha256-0jshXmzkVPB24WOj/rehtUjd9EvjpBNT90g3cisR1sU=";
+        name = "tmp@0.2.3";
+        url = "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz";
+        hash = "sha256-2RpVWSJq+LX2jF8LVJRYgBKGU37zN0txPbLUTohwmpU=";
+      };
+    };
+    "tmp-promise" = {
+      out_path = "tmp-promise";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "tmp-promise@3.0.3";
+        url = "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz";
+        hash = "sha256-nYhMJRQeRKRNiTsva4Dl68WuijSkv/kITxmIDnS7ydk=";
       };
     };
     "to-regex-range" = {
@@ -5686,6 +6138,17 @@ let
         name = "to-regex-range@5.0.1";
         url = "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz";
         hash = "sha256-pjolXsIKk1w6MzSmZF+SRds24jGd3x62vA6rK/5bQtc=";
+      };
+    };
+    "tr46" = {
+      out_path = "tr46";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "tr46@0.0.3";
+        url = "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz";
+        hash = "sha256-Fkrh6zLOo1NVG7x/k1jcquT/q75l7DepLKRkqVcKKgo=";
       };
     };
     "ts-api-utils" = {
@@ -5898,6 +6361,28 @@ let
         hash = "sha256-AWbvs01BoTHU3yp1+P+EMUvjXA2s9v7CZWAt5md3/Yw=";
       };
     };
+    "webidl-conversions" = {
+      out_path = "webidl-conversions";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "webidl-conversions@3.0.1";
+        url = "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz";
+        hash = "sha256-5N/DS0CUfCzwA4zZX6beIfTayTIkp62OFpIF9cLiLag=";
+      };
+    };
+    "whatwg-url" = {
+      out_path = "whatwg-url";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "whatwg-url@5.0.0";
+        url = "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz";
+        hash = "sha256-sJ3EcfVzqHburDkCuMHaYq9c27yixvukoG8Rn4nLftM=";
+      };
+    };
     "which" = {
       out_path = "which";
       binaries = {
@@ -5984,6 +6469,28 @@ let
         name = "ansi-styles@6.2.1";
         url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz";
         hash = "sha256-aPDnPT8um3lKOI3H9OmhmCcCc6C8pIzWjc+eCM88XRg=";
+      };
+    };
+    "ws" = {
+      out_path = "ws";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "ws@8.18.1";
+        url = "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz";
+        hash = "sha256-1DybgsiOWE7KOvYK07wktGkNsVdgzCApeqIPJuWB3pY=";
+      };
+    };
+    "yallist" = {
+      out_path = "yallist";
+      binaries =
+        {
+        };
+      pkg = fetchurl {
+        name = "yallist@5.0.0";
+        url = "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz";
+        hash = "sha256-fJ1D26t8qzsxM7Dmpa8UAUSCKFMWs57J9QjvrdnrzpU=";
       };
     };
     "yaml" = {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,6 +42,7 @@
     "@aws-sdk/client-s3": "^3.787.0",
     "@aws-sdk/client-sts": "^3.787.0",
     "@inquirer/prompts": "^7.4.0",
+    "@kubernetes/client-node": "^1.1.2",
     "@listr2/prompt-adapter-inquirer": "^2.0.21",
     "@types/ini": "^4.1.1",
     "clipanion": "^4.0.0-rc.4",

--- a/packages/cli/src/commands/cluster/add/setupCertIssuers.ts
+++ b/packages/cli/src/commands/cluster/add/setupCertIssuers.ts
@@ -186,6 +186,9 @@ export async function setupCertificateIssuers(
                   // Doing this up front to wait the first time
                   await new Promise(resolve => globalThis.setTimeout(resolve, retryDelay));
 
+                  const statusStr = `attempt ${attempts + 1}/${maxAttempts}`
+                  task.title = context.logger.applyColors(`Resetting Cert Manager ${statusStr}`, { lowlights: [statusStr] });
+
                   let result;
                   try {
                     const { stdout } = await execute({

--- a/packages/cli/src/commands/cluster/add/setupInboundNetworking.ts
+++ b/packages/cli/src/commands/cluster/add/setupInboundNetworking.ts
@@ -208,11 +208,7 @@ export async function setupInboundNetworking(
 
                       while (attempts < maxAttempts) {
                         // Doing this up front to wait the first time
-                        if (attempts < maxAttempts) {
-                          await new Promise(resolve => globalThis.setTimeout(resolve, retryDelay));
-                        } else {
-                          throw new CLIError(`Failed to progress after resetting cert-manager ${maxAttempts} times`);
-                        }
+                        await new Promise(resolve => globalThis.setTimeout(resolve, retryDelay));
 
                         try {
                           // Get Certificate resources
@@ -263,6 +259,7 @@ export async function setupInboundNetworking(
                           throw new CLIError(`Failed to restart cert-manager`, error);
                         }
                       }
+                      throw new CLIError(`Failed to progress after resetting cert-manager ${maxAttempts} times`);
                     }
                   }
                 ], { ctx, concurrent: true })

--- a/packages/cli/src/commands/cluster/add/setupInboundNetworking.ts
+++ b/packages/cli/src/commands/cluster/add/setupInboundNetworking.ts
@@ -196,12 +196,6 @@ export async function setupInboundNetworking(
                       const maxAttempts = 10;
                       const retryDelay = 90000;
 
-                      if (attempts < maxAttempts) {
-                        await new Promise(resolve => globalThis.setTimeout(resolve, retryDelay));
-                      } else {
-                        throw new CLIError(`Failed to progress after resetting cert-manager ${maxAttempts} times`);
-                      }
-
                       const kc = new KubeConfig();
                       kc.loadFromDefault();
                       if (!kubeConfigContext) {
@@ -213,6 +207,13 @@ export async function setupInboundNetworking(
                       const appsApi = kc.makeApiClient(AppsV1Api);
 
                       while (attempts < maxAttempts) {
+                        // Doing this up front to wait the first time
+                        if (attempts < maxAttempts) {
+                          await new Promise(resolve => globalThis.setTimeout(resolve, retryDelay));
+                        } else {
+                          throw new CLIError(`Failed to progress after resetting cert-manager ${maxAttempts} times`);
+                        }
+
                         try {
                           // Get Certificate resources
                           const result = await customApi.listClusterCustomObject({

--- a/packages/cli/src/commands/cluster/add/setupInboundNetworking.ts
+++ b/packages/cli/src/commands/cluster/add/setupInboundNetworking.ts
@@ -238,27 +238,27 @@ export async function setupInboundNetworking(
                               if (isCertReady) {
                                 return;
                               }
-
-                              // Restart cert-manager deployment
-                              await appsApi.patchNamespacedDeployment({
-                                name: 'cert-manager',
-                                namespace: 'cert-manager',
-                                body: {
-                                  spec: {
-                                    template: {
-                                      metadata: {
-                                        annotations: {
-                                          'kubectl.kubernetes.io/restartedAt': new Date().toISOString()
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                              });
-
-                              attempts++;
                             }
                           }
+
+                          // Restart cert-manager deployment
+                          await appsApi.patchNamespacedDeployment({
+                            name: 'cert-manager',
+                            namespace: 'cert-manager',
+                            body: {
+                              spec: {
+                                template: {
+                                  metadata: {
+                                    annotations: {
+                                      'kubectl.kubernetes.io/restartedAt': new Date().toISOString()
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                          });
+
+                          attempts++;
                         } catch (error) {
                           throw new CLIError(`Failed to restart cert-manager`, error);
                         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds retry logic to reset cert manager during nginx ingress deployment, ensuring certificate readiness with new Kubernetes client dependency.
> 
>   - **Behavior**:
>     - Adds retry logic in `setupCertIssuers.ts` to reset cert manager up to 10 times, waiting 90 seconds between attempts, until the certificate is ready.
>     - Uses `kubectl` to check certificate status and restart cert-manager deployment if necessary.
>   - **Dependencies**:
>     - Adds `@kubernetes/client-node` to `package.json`.
>     - Updates `bun.lock` and `bun.nix` to include new dependencies related to Kubernetes client.
>   - **Error Handling**:
>     - Throws `CLIError` if certificate retrieval or parsing fails, or if cert-manager restart fails after max attempts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Panfactum%2Fstack&utm_source=github&utm_medium=referral)<sup> for 503f9dfc642fcbe45fe7a1d0ed7a436e75995011. You can [customize](https://app.ellipsis.dev/Panfactum/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->