### PR TITLE
Federated auth

### DIFF
--- a/packages/cli/src/commands/cluster/add/setupVault.ts
+++ b/packages/cli/src/commands/cluster/add/setupVault.ts
@@ -18,7 +18,6 @@ import {
   defineInputUpdate,
 } from "@/util/terragrunt/tasks/deployModuleTask";
 import { readYAMLFile } from "@/util/yaml/readYAMLFile";
-import { writeYAMLFile } from "@/util/yaml/writeYAMLFile";
 import type { InstallClusterStepOptions } from "./common";
 import type { PanfactumTaskWrapper } from "@/util/listr/types";
 
@@ -227,14 +226,14 @@ export async function setupVault(
           const data = JSON.parse(stdout.trim());
           recoveryKeys = RECOVER_KEYS_SCHEMA.parse(data);
         } catch (error) {
-          await writeYAMLFile({
-            context,
-            values: {
-              status: "error",
-            },
-            overwrite: true,
-            filePath: join(modulePath, ".pf.yaml"),
-          });
+          // await writeYAMLFile({
+          //   context,
+          //   values: {
+          //     status: "error",
+          //   },
+          //   overwrite: true,
+          //   filePath: join(modulePath, ".pf.yaml"),
+          // });
           parseErrorHandler({
             error,
             errorMessage: "Failed to parse vault operator init",

--- a/packages/cli/src/commands/cluster/add/setupVault.ts
+++ b/packages/cli/src/commands/cluster/add/setupVault.ts
@@ -18,6 +18,7 @@ import {
   defineInputUpdate,
 } from "@/util/terragrunt/tasks/deployModuleTask";
 import { readYAMLFile } from "@/util/yaml/readYAMLFile";
+import { writeYAMLFile } from "@/util/yaml/writeYAMLFile";
 import type { InstallClusterStepOptions } from "./common";
 import type { PanfactumTaskWrapper } from "@/util/listr/types";
 
@@ -226,14 +227,14 @@ export async function setupVault(
           const data = JSON.parse(stdout.trim());
           recoveryKeys = RECOVER_KEYS_SCHEMA.parse(data);
         } catch (error) {
-          // await writeYAMLFile({
-          //   context,
-          //   values: {
-          //     status: "error",
-          //   },
-          //   overwrite: true,
-          //   filePath: join(modulePath, ".pf.yaml"),
-          // });
+          await writeYAMLFile({
+            context,
+            values: {
+              status: "error",
+            },
+            overwrite: true,
+            filePath: join(modulePath, ".pf.yaml"),
+          });
           parseErrorHandler({
             error,
             errorMessage: "Failed to parse vault operator init",

--- a/packages/cli/src/commands/sso/add/command.ts
+++ b/packages/cli/src/commands/sso/add/command.ts
@@ -8,6 +8,7 @@ import { CLIError } from "@/util/error/error";
 import { MODULES } from "@/util/terragrunt/constants";
 import { readYAMLFile } from "@/util/yaml/readYAMLFile";
 import { setupAuthentik } from "./setupAuthentik";
+import { setupFederatedAuth } from "./setupFederatedAuth";
 
 export class SSOAddCommand extends PanfactumCommand {
     static override paths = [["sso", "add"]];
@@ -63,6 +64,13 @@ export class SSOAddCommand extends PanfactumCommand {
             },
             task: async (_, mainTask) => {
                 return setupAuthentik(this.context, mainTask);
+            }
+        });
+
+        tasks.add({
+            title: this.context.logger.applyColors("Setup Federated Auth"),
+            task: async (_, mainTask) => {
+                return setupFederatedAuth(this.context, mainTask);
             }
         });
 

--- a/packages/cli/src/commands/sso/add/command.ts
+++ b/packages/cli/src/commands/sso/add/command.ts
@@ -52,15 +52,16 @@ export class SSOAddCommand extends PanfactumCommand {
         tasks.add({
             title: this.context.logger.applyColors("Setup Authentik"),
             skip: async () => {
-                const authentikCoreResourcesConfig = await readYAMLFile({
-                    filePath: join(clusterPath, MODULES.AUTHENTIK_CORE_RESOURCES, "module.yaml"),
+                const authentikCoreResourcesPfYAMLFileData = await readYAMLFile({
+                    filePath: join(clusterPath, MODULES.AUTHENTIK_CORE_RESOURCES, ".pf.yaml"),
                     context: this.context,
                     validationSchema: z
                         .object({
-                            user_setup_complete: z.boolean().optional()
-                        }).passthrough(),
-                });
-                return !!authentikCoreResourcesConfig?.user_setup_complete;
+                            user_setup_complete: z.boolean().optional(),
+                        })
+                        .passthrough(),
+                })
+                return !!authentikCoreResourcesPfYAMLFileData?.user_setup_complete;
             },
             task: async (_, mainTask) => {
                 return setupAuthentik(this.context, mainTask);

--- a/packages/cli/src/commands/sso/add/setupFederatedAuth.ts
+++ b/packages/cli/src/commands/sso/add/setupFederatedAuth.ts
@@ -141,7 +141,7 @@ export async function setupFederatedAuth(
                     if (!ctx.awsSignInUrl) {
                         const identityCenterURLChanged = await context.logger.confirm({
                             task,
-                            explainer: "We need to setup IAM Identity Center in the ${globalRegionYAMLData.aws_region} region.\n\n" +
+                            explainer: `We need to setup IAM Identity Center in the ${globalRegionData.aws_region} region.\n\n` +
                                 "Follow these instruction to change the portal URL:\n\n" +
                                 "https://docs.aws.amazon.com/singlesignon/latest/userguide/howtochangeURL.html\n\n" +
                                 "Keep the page open when you're done.",

--- a/packages/cli/src/commands/sso/add/setupFederatedAuth.ts
+++ b/packages/cli/src/commands/sso/add/setupFederatedAuth.ts
@@ -442,6 +442,7 @@ export async function setupFederatedAuth(
             region: GLOBAL_REGION,
             module: MODULES.AWS_IAM_IDENTITY_CENTER_PERMISSIONS,
             hclIfMissing: await Bun.file(awsIamIdentityCenterPermissions).text(),
+            skipIfAlreadyApplied: true,
             inputUpdates: {
                 account_access_configuration: defineInputUpdate({
                     schema: z.record(z.string(), z.object({

--- a/packages/cli/src/commands/sso/add/setupFederatedAuth.ts
+++ b/packages/cli/src/commands/sso/add/setupFederatedAuth.ts
@@ -233,11 +233,11 @@ export async function setupFederatedAuth(
                     context,
                     filePath: join(clusterPath, MODULES.AUTHENTIK_AWS_SSO, "secrets.yaml"),
                     validationSchema: z.object({
-                        aws_skim_token: z.string().optional()
+                        aws_scim_token: z.string().optional()
                     })
                 })
 
-                return !secrets?.aws_skim_token || !ctx.awsScimUrl
+                return !secrets?.aws_scim_token || !ctx.awsScimUrl
             },
             task: async (ctx, task) => {
                 const authentikModuleFilePath = join(clusterPath, MODULES.KUBE_AUTHENTIK, "module.yaml")
@@ -282,19 +282,19 @@ export async function setupFederatedAuth(
                     context,
                     filePath: join(clusterPath, MODULES.AUTHENTIK_AWS_SSO, "secrets.yaml"),
                     validationSchema: z.object({
-                        aws_skim_token: z.string().optional()
+                        aws_scim_token: z.string().optional()
                     })
                 })
 
                 if (!ctx.awsScimUrl) {
                     ctx.awsScimUrl = await context.logger.input({
                         task,
-                        message: "Enter the SCIM encpoint from the modal:",
+                        message: "Enter the SCIM endpoint from the modal:",
                         required: true,
                     })
                 }
 
-                if (!skimToken?.aws_skim_token) {
+                if (!skimToken?.aws_scim_token) {
                     const awsSCIMToken = await context.logger.password({
                         task,
                         message: "Enter the Access token from the modal:",

--- a/packages/cli/src/files/terragrunt/panfactum.hcl
+++ b/packages/cli/src/files/terragrunt/panfactum.hcl
@@ -355,7 +355,8 @@ generate "authentik_provider" {
   disable     = !local.enable_authentik
   if_disabled = "remove"
   contents = templatefile("${local.provider_folder}/authentik.tftpl", {
-    authentik_url = lookup(local.vars, "authentik_url", "@@TERRAGRUNT_INVALID@@")
+    authentik_url   = lookup(local.vars, "authentik_url", "@@TERRAGRUNT_INVALID@@")
+    authentik_token = lookup(local.vars, "authentik_token", "@@TERRAGRUNT_INVALID@@")
   })
 }
 

--- a/packages/cli/src/files/terragrunt/providers/authentik.tftpl
+++ b/packages/cli/src/files/terragrunt/providers/authentik.tftpl
@@ -3,7 +3,8 @@
 #################################################################
 
 provider "authentik" {
-  url = "${authentik_url}"
+  url   = "${authentik_url}"
+  token = "${authentik_token}"
 }
 
 

--- a/packages/cli/src/util/config/schemas.ts
+++ b/packages/cli/src/util/config/schemas.ts
@@ -84,6 +84,7 @@ export const PANFACTUM_CONFIG_SCHEMA = z.object({
 
   // Authentik Provider
   authentik_url: z.string().optional(),
+  authentik_token: z.string().optional()
 }).strict();
 
 export type TGConfigFile = z.infer<typeof PANFACTUM_CONFIG_SCHEMA>;

--- a/packages/cli/src/util/yaml/upsertPFYAMLFile.ts
+++ b/packages/cli/src/util/yaml/upsertPFYAMLFile.ts
@@ -1,0 +1,63 @@
+import { join } from "path";
+import { z } from "zod";
+import { readYAMLFile } from "./readYAMLFile";
+import { writeYAMLFile } from "./writeYAMLFile";
+import { fileExists } from "../fs/fileExists";
+import type { PanfactumContext } from "@/util/context/context";
+
+type JSONValue =
+    | string
+    | number
+    | boolean
+    | null
+    | JSONValue[]
+    | { [key: string]: JSONValue };
+
+export async function upsertPFYAMLFile(inputs: {
+    context: PanfactumContext;
+    environment: string;
+    region: string;
+    module: string;
+    updates: Record<string, JSONValue>;
+    realModuleName?: string;
+}) {
+    const { context, environment, region, module, realModuleName, updates } =
+        inputs;
+
+    const moduleDir = join(
+        context.repoVariables.environments_dir,
+        environment,
+        region,
+        module
+    );
+
+    const pfYAMLPath = join(moduleDir, ".pf.yaml");
+    if (await fileExists(pfYAMLPath)) {
+        const originalPf = await readYAMLFile({
+            filePath: pfYAMLPath,
+            context,
+            validationSchema: z
+                .object({}).passthrough(),
+        });
+        const newModuleConfig = {
+            module: realModuleName,
+            ...originalPf,
+            ...updates,
+        };
+        await writeYAMLFile({
+            context,
+            filePath: pfYAMLPath,
+            values: newModuleConfig,
+            overwrite: true,
+        });
+    } else {
+        await writeYAMLFile({
+            context,
+            filePath: pfYAMLPath,
+            values: {
+                ...updates,
+            },
+            overwrite: true,
+        });
+    }
+}


### PR DESCRIPTION
One new pattern, with the introduction of the `module.status.yaml` I started using the `.pf.yaml` for arbitrary data. Such as capturing when a non-module step has been completed or not or user input that isn't used for module inputs.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds federated authentication support with Authentik and AWS SSO integration, utilizing `.pf.yaml` for configuration management.
> 
>   - **Behavior**:
>     - Adds `setupFederatedAuth` task in `command.ts` to handle federated authentication setup.
>     - Introduces `.pf.yaml` for storing arbitrary data, replacing direct `module.yaml` reads.
>     - Updates `setupAuthentik` and `setupFederatedAuth` to use `upsertPFYAMLFile` for configuration updates.
>   - **Configuration**:
>     - Adds `authentik_token` to `PANFACTUM_CONFIG_SCHEMA` in `schemas.ts`.
>     - Updates `authentik.tftpl` to include `authentik_token`.
>   - **Utilities**:
>     - New `upsertPFYAMLFile` function in `upsertPFYAMLFile.ts` for updating `.pf.yaml` files.
>     - Modifies `panfactum.hcl` to include `authentik_token` in provider configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Panfactum%2Fstack&utm_source=github&utm_medium=referral)<sup> for 17cdaa4df9db2423ed6ebf525a24943eb5c9d19d. You can [customize](https://app.ellipsis.dev/Panfactum/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->