### PR TITLE
feat: add posthog

### DIFF
--- a/packages/website/src/layouts/CommonHead.astro
+++ b/packages/website/src/layouts/CommonHead.astro
@@ -111,5 +111,12 @@ const { title, description, redirect } = Astro.props;
 
   gtag('config', 'G-EX534J6X8H');
 </script>
+<script is:inline>
+  !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init be ys Ss me gs ws capture Le calculateEventProperties xs register register_once register_for_session unregister unregister_for_session Rs getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Is ks createPersonProfile Ps bs opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing $s debug Es getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+  posthog.init('phc_lc2HxJoKHiUOqvjW7pGsWTLaXj7gTGEO59KYGdMEYSc', {
+      api_host: 'https://us.i.posthog.com',
+      person_profiles: 'identified_only', // or 'always' to create profiles for anonymous users as well
+  })
+</script>
 )}
 

--- a/packages/website/src/pages/index.astro
+++ b/packages/website/src/pages/index.astro
@@ -7,7 +7,6 @@ import ReplacedServicesSection from "./_components/ReplacedServicesSection/Repla
 import Layout from "../layouts/Layout.astro";
 import MainSection from "../layouts/MainSection.astro";
 ---
-
 <Layout
   heroClass="bg-secondary"
   hasBorder={false}


### PR DESCRIPTION
Confirmed I could see a session before I moved it inside the conditional block:
![image](https://github.com/user-attachments/assets/945513fd-d103-48f8-b4de-90fa32b64440)
Followed the docs for integrating with Astro https://posthog.com/docs/libraries/astro
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add PostHog analytics script to `CommonHead.astro` for production environments.
> 
>   - **Analytics Integration**:
>     - Adds PostHog analytics script to `CommonHead.astro` for tracking user interactions.
>     - Script is conditionally included only in production environments.
>   - **Misc**:
>     - Removes an unnecessary newline in `index.astro`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Panfactum%2Fstack&utm_source=github&utm_medium=referral)<sup> for 3b2595f5a95073ff0f971deb46f97defbe10d453. You can [customize](https://app.ellipsis.dev/Panfactum/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->