### PR TITLE
feat(kube_pg_cluster): support targetImmediate recovery

### DIFF
--- a/packages/infrastructure/kube_pg_cluster/main.tf
+++ b/packages/infrastructure/kube_pg_cluster/main.tf
@@ -386,6 +386,9 @@ resource "kubernetes_manifest" "postgres_cluster" {
           source = var.pg_recovery_directory
           recoveryTarget = var.pg_recovery_target_time != null ? {
             targetTime = var.pg_recovery_target_time
+            } : var.pg_recovery_target_immediate != null ? {
+            backendID       = var.pg_recovery_target_immediate
+            targetImmediate = true
           } : null
         } : k => v if v != null } : null
         initdb = !var.pg_recovery_mode_enabled ? {

--- a/packages/infrastructure/kube_pg_cluster/vars.tf
+++ b/packages/infrastructure/kube_pg_cluster/vars.tf
@@ -542,6 +542,12 @@ variable "pg_recovery_bucket" {
   default     = null
 }
 
+variable "pg_recovery_target_immediate" {
+  description = "Name of the base backup directory to immediately stop at. When restoring from an online backup, this means the point where taking the backup ended."
+  type        = string
+  default     = null
+}
+
 
 variable "pg_backup_directory" {
   description = "The name of the directory in the backup bucket containing the backups files."

--- a/packages/website/src/content/docs/main/modules.json
+++ b/packages/website/src/content/docs/main/modules.json
@@ -196,17 +196,17 @@
       "group": "kubernetes"
     },
     {
-      "module": "kube_certificates",
-      "type": "direct",
-      "group": "kubernetes"
-    },
-    {
       "module": "kube_cert_issuers",
       "type": "direct",
       "group": "kubernetes"
     },
     {
       "module": "kube_cert_manager",
+      "type": "direct",
+      "group": "kubernetes"
+    },
+    {
+      "module": "kube_certificates",
       "type": "direct",
       "group": "kubernetes"
     },

--- a/packages/website/src/content/docs/main/modules.json
+++ b/packages/website/src/content/docs/main/modules.json
@@ -196,17 +196,17 @@
       "group": "kubernetes"
     },
     {
+      "module": "kube_certificates",
+      "type": "direct",
+      "group": "kubernetes"
+    },
+    {
       "module": "kube_cert_issuers",
       "type": "direct",
       "group": "kubernetes"
     },
     {
       "module": "kube_cert_manager",
-      "type": "direct",
-      "group": "kubernetes"
-    },
-    {
-      "module": "kube_certificates",
       "type": "direct",
       "group": "kubernetes"
     },

--- a/packages/website/src/content/docs/main/reference/infrastructure-modules/submodule/kubernetes/kube_pg_cluster/index.mdx
+++ b/packages/website/src/content/docs/main/reference/infrastructure-modules/submodule/kubernetes/kube_pg_cluster/index.mdx
@@ -635,6 +635,14 @@ Type: `bool`
 
 Default: `false`
 
+### pg\_recovery\_target\_immediate
+
+Description: Name of the base backup directory to immediately stop at. When restoring from an online backup, this means the point where taking the backup ended.
+
+Type: `string`
+
+Default: `null`
+
 ### pg\_recovery\_target\_time
 
 Description: If provided, will recover the database to the indicated target time in RFC 3339 format rather than to the latest data.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds support for immediate recovery in `kube_pg_cluster` by introducing `pg_recovery_target_immediate` variable.
> 
>   - **Behavior**:
>     - Adds support for `targetImmediate` recovery in `kube_pg_cluster/main.tf` by introducing `pg_recovery_target_immediate` variable.
>     - Allows recovery to stop at the point where the backup ended.
>   - **Variables**:
>     - Adds `pg_recovery_target_immediate` to `vars.tf` with type `string` and default `null`.
>   - **Documentation**:
>     - Updates `index.mdx` to include `pg_recovery_target_immediate` description.
>   - **Misc**:
>     - Renames modules in `modules.json` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Panfactum%2Fstack&utm_source=github&utm_medium=referral)<sup> for bb20bd62b0c80459175f97ed0d8e864a99a844d7. You can [customize](https://app.ellipsis.dev/Panfactum/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->