### PR TITLE
feat(kube_pg_cluster): support custom_image

### DIFF
--- a/packages/infrastructure/kube_pg_cluster/main.tf
+++ b/packages/infrastructure/kube_pg_cluster/main.tf
@@ -280,7 +280,7 @@ resource "kubernetes_manifest" "postgres_cluster" {
       }
     }
     spec = { for k, v in {
-      imageName             = "${module.pull_through.github_registry}/cloudnative-pg/postgresql:${var.pg_version}"
+      imageName             = var.pg_custom_image != null ? var.pg_custom_image : "${module.pull_through.github_registry}/cloudnative-pg/postgresql:${var.pg_version}"
       instances             = var.pg_instances
       minSyncReplicas       = var.pg_sync_replication_enabled ? var.pg_instances - 1 : 0
       primaryUpdateStrategy = "unsupervised"

--- a/packages/infrastructure/kube_pg_cluster/vars.tf
+++ b/packages/infrastructure/kube_pg_cluster/vars.tf
@@ -14,6 +14,27 @@ variable "pg_version" {
   default     = "16.6-13"
 }
 
+variable "pg_custom_image" {
+  description = <<-EOT
+    Custom PostgreSQL container image to use instead of the default CloudNativePG image.
+    
+    This allows you to use:
+    - Pre-built CNPG images with extensions (e.g., 'ghcr.io/cloudnative-pg/postgis:17')
+    - Custom-built images with your own extensions (e.g., 'myregistry.io/postgres:16.9-custom')
+    
+    When set, this overrides the 'pg_version' variable for image selection.
+    The image must be compatible with CloudNativePG requirements.
+    
+    Note: Custom images bypass the ECR pull through cache. Ensure your cluster
+    has appropriate image pull secrets and registry access configured.
+    
+    Example building custom image with pgvector:
+    See https://cloudnative-pg.io/blog/building-images-bake/
+  EOT
+  type        = string
+  default     = null
+}
+
 variable "pg_instances" {
   description = "The number of instances to deploy in the postgres cluster"
   type        = number


### PR DESCRIPTION
Support building a custom postgres image in order to allow adding extensions for example pg_duckdb and pg_vector.

TODO:

* [ ] Test in a real cluster
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for custom PostgreSQL images with extensions by introducing `pg_custom_image` variable and updating image selection logic.
> 
>   - **Behavior**:
>     - Adds support for custom PostgreSQL images with extensions by introducing `pg_custom_image` variable in `vars.tf`.
>     - Modifies `imageName` logic in `main.tf` to use `pg_custom_image` if set, otherwise defaults to `pg_version`.
>   - **Documentation**:
>     - Updates `README.md` with instructions for using pre-built and custom PostgreSQL images, including building custom images with Docker Bake.
>     - Lists available extensions and provides warnings about using custom images.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Panfactum%2Fstack&utm_source=github&utm_medium=referral)<sup> for 7459871e933f45d4d23d87d8887927acad6ca364. You can [customize](https://app.ellipsis.dev/Panfactum/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->